### PR TITLE
Implement UI redesign plan and WAV import support

### DIFF
--- a/Source/App/MainWindow.cpp
+++ b/Source/App/MainWindow.cpp
@@ -10,8 +10,8 @@ MainWindow::MainWindow(AudioEngine& engine, SourceSampleManager& sampleManager)
 {
     setUsingNativeTitleBar(true);
     setContentOwned(new MainEditor(engine, sampleManager), true);
-    setResizable(true, true);
-    setResizeLimits(900, 600, 2400, 1400);
+    setResizable(false, false);
+    setResizeLimits(1100, 780, 1100, 780);
     centreWithSize(getWidth(), getHeight());
     setVisible(true);
 }

--- a/Source/Modulation/LFO.h
+++ b/Source/Modulation/LFO.h
@@ -18,7 +18,7 @@ enum class LFOShape
  * LFO with phase accumulator.
  * Outputs normalized value in [-1, 1].
  * Shapes: sine, triangle, square, sample-and-hold (random).
- * Rate: free Hz or tempo-synced (not in V1 — free only for now).
+ * Rate: free Hz or tempo-synced against a UI-provided BPM.
  * Audio-thread safe.
  */
 class LFO
@@ -34,9 +34,28 @@ public:
     void setRate(float hz) { rate.store(juce::jlimit(0.01f, 30.0f, hz), std::memory_order_relaxed); }
     void setDepth(float d) { depth.store(juce::jlimit(0.0f, 1.0f, d), std::memory_order_relaxed); }
     void setShape(LFOShape s) { shape.store(static_cast<int>(s), std::memory_order_relaxed); }
+    void setTempoSync(bool shouldSync, float newBpm, float noteDivision)
+    {
+        tempoSyncEnabled.store(shouldSync, std::memory_order_relaxed);
+        bpm.store(juce::jlimit(20.0f, 300.0f, newBpm), std::memory_order_relaxed);
+        syncDivision.store(juce::jmax(0.125f, noteDivision), std::memory_order_relaxed);
+    }
 
     LFOShape getShape() const { return static_cast<LFOShape>(shape.load(std::memory_order_relaxed)); }
     float getDepth() const { return depth.load(std::memory_order_relaxed); }
+    bool isTempoSynced() const { return tempoSyncEnabled.load(std::memory_order_relaxed); }
+    float getRate() const { return rate.load(std::memory_order_relaxed); }
+    float getSyncDivision() const { return syncDivision.load(std::memory_order_relaxed); }
+    float getBPM() const { return bpm.load(std::memory_order_relaxed); }
+    float getEffectiveRateHz() const
+    {
+        if (!tempoSyncEnabled.load(std::memory_order_relaxed))
+            return rate.load(std::memory_order_relaxed);
+
+        const auto currentBpm = bpm.load(std::memory_order_relaxed);
+        const auto division = juce::jmax(0.125f, syncDivision.load(std::memory_order_relaxed));
+        return currentBpm / (60.0f * division);
+    }
 
     // Reset phase (e.g., on note trigger)
     void resetPhase() { phase = 0.0; }
@@ -47,7 +66,7 @@ public:
         if (!enabled.load(std::memory_order_relaxed))
             return 0.0f;
 
-        float currentRate = rate.load(std::memory_order_relaxed);
+        const float currentRate = getEffectiveRateHz();
         float currentDepth = depth.load(std::memory_order_relaxed);
         auto currentShape = static_cast<LFOShape>(shape.load(std::memory_order_relaxed));
 
@@ -110,6 +129,9 @@ private:
     std::atomic<float> rate { 1.0f };   // Hz
     std::atomic<float> depth { 0.5f };
     std::atomic<int> shape { static_cast<int>(LFOShape::Sine) };
+    std::atomic<bool> tempoSyncEnabled { false };
+    std::atomic<float> bpm { 120.0f };
+    std::atomic<float> syncDivision { 1.0f }; // quarter-note units (1.0 = quarter, 0.5 = eighth)
 
     double phase = 0.0;
     double sampleRate = 44100.0;

--- a/Source/SourceInput/AudioFileLoader.cpp
+++ b/Source/SourceInput/AudioFileLoader.cpp
@@ -55,13 +55,14 @@ AudioFileLoader::LoadResult AudioFileLoader::loadFile(const juce::File& file)
 bool AudioFileLoader::isFormatSupported(const juce::File& file) const
 {
     auto extension = file.getFileExtension().toLowerCase();
-    return extension == ".wav" || extension == ".aiff" || extension == ".aif"
+    return extension == ".wav" || extension == ".wave"
+        || extension == ".aiff" || extension == ".aif"
         || extension == ".flac";
 }
 
 juce::String AudioFileLoader::getSupportedFormatsWildcard() const
 {
-    return "*.wav;*.aiff;*.aif;*.flac";
+    return "*.wav;*.wave;*.aiff;*.aif;*.flac";
 }
 
 } // namespace grainhex

--- a/Source/SourceInput/AudioFileLoader.h
+++ b/Source/SourceInput/AudioFileLoader.h
@@ -8,7 +8,7 @@ namespace grainhex {
 
 /**
  * Loads audio files off the audio thread.
- * Supports WAV, AIFF, FLAC.
+ * Supports WAV/WAVE, AIFF, FLAC.
  * Decodes to float and normalizes mono/stereo.
  */
 class AudioFileLoader

--- a/Source/UI/EffectsPanel.cpp
+++ b/Source/UI/EffectsPanel.cpp
@@ -2,12 +2,45 @@
 
 namespace grainhex {
 
+namespace {
+
+void styleLabel(juce::Label& label)
+{
+    label.setJustificationType(juce::Justification::centredLeft);
+    label.setFont(juce::Font(Theme::fontLabel));
+    label.setColour(juce::Label::textColourId, juce::Colour(Theme::textNormal));
+}
+
+void styleSlider(juce::Slider& slider, double min, double max, double def, double step)
+{
+    slider.setRange(min, max, step);
+    slider.setValue(def, juce::dontSendNotification);
+    slider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
+    slider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 60, 16);
+    slider.setColour(juce::Slider::rotarySliderFillColourId, juce::Colour(Theme::accentOrange));
+}
+
+void styleCombo(juce::ComboBox& box)
+{
+    box.setColour(juce::ComboBox::backgroundColourId, juce::Colour(Theme::bgControl));
+    box.setColour(juce::ComboBox::outlineColourId, juce::Colour(Theme::border));
+    box.setColour(juce::ComboBox::textColourId, juce::Colour(Theme::textNormal));
+}
+
+} // namespace
+
 EffectsPanel::EffectsPanel()
 {
-    // -- Distortion section --
     addAndMakeVisible(distortionToggle);
     distortionToggle.setToggleState(false, juce::dontSendNotification);
-    distortionToggle.onClick = [this] { parameterChanged(); };
+    distortionToggle.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentOrange));
+    distortionToggle.onClick = [this]
+    {
+        updateSectionVisibility();
+        resized();
+        repaint();
+        parameterChanged();
+    };
 
     addAndMakeVisible(distortionModeBox);
     distortionModeBox.addItem("Soft Clip", 1);
@@ -15,29 +48,7 @@ EffectsPanel::EffectsPanel()
     distortionModeBox.addItem("Wavefold", 3);
     distortionModeBox.setSelectedId(1, juce::dontSendNotification);
     distortionModeBox.onChange = [this] { parameterChanged(); };
-    addAndMakeVisible(distortionModeLabel);
-
-    auto setupSlider = [this](juce::Slider& s, juce::Label& l, double min, double max, double def, double step)
-    {
-        addAndMakeVisible(s);
-        s.setRange(min, max, step);
-        s.setValue(def, juce::dontSendNotification);
-        s.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-        s.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 60, 16);
-        s.onValueChange = [this] { parameterChanged(); };
-        addAndMakeVisible(l);
-        l.setJustificationType(juce::Justification::centred);
-        l.setFont(juce::Font(11.0f));
-        l.setColour(juce::Label::textColourId, juce::Colours::lightgrey);
-    };
-
-    setupSlider(driveSlider, driveLabel, 1.0, 20.0, 1.0, 0.1);
-    setupSlider(distMixSlider, distMixLabel, 0.0, 1.0, 0.0, 0.01);
-
-    // -- Filter section --
-    addAndMakeVisible(filterToggle);
-    filterToggle.setToggleState(false, juce::dontSendNotification);
-    filterToggle.onClick = [this] { parameterChanged(); };
+    styleCombo(distortionModeBox);
 
     addAndMakeVisible(filterModeBox);
     filterModeBox.addItem("Low Pass", 1);
@@ -45,13 +56,44 @@ EffectsPanel::EffectsPanel()
     filterModeBox.addItem("Band Pass", 3);
     filterModeBox.setSelectedId(1, juce::dontSendNotification);
     filterModeBox.onChange = [this] { parameterChanged(); };
-    addAndMakeVisible(filterModeLabel);
+    styleCombo(filterModeBox);
 
-    setupSlider(cutoffSlider, cutoffLabel, 20.0, 20000.0, 8000.0, 1.0);
+    addAndMakeVisible(filterToggle);
+    filterToggle.setToggleState(false, juce::dontSendNotification);
+    filterToggle.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentOrange));
+    filterToggle.onClick = [this]
+    {
+        updateSectionVisibility();
+        resized();
+        repaint();
+        parameterChanged();
+    };
+
+    styleSlider(driveSlider, 1.0, 20.0, 1.0, 0.1);
+    styleSlider(distMixSlider, 0.0, 1.0, 0.0, 0.01);
+    styleSlider(cutoffSlider, 20.0, 20000.0, 8000.0, 1.0);
+    styleSlider(resonanceSlider, 0.0, 1.0, 0.0, 0.01);
+    styleSlider(envAmountSlider, -96.0, 96.0, 48.0, 1.0);
     cutoffSlider.setSkewFactorFromMidPoint(1000.0);
 
-    setupSlider(resonanceSlider, resonanceLabel, 0.0, 1.0, 0.0, 0.01);
-    setupSlider(envAmountSlider, envAmountLabel, -96.0, 96.0, 48.0, 1.0);
+    for (auto* slider : { &driveSlider, &distMixSlider, &cutoffSlider, &resonanceSlider, &envAmountSlider })
+    {
+        addAndMakeVisible(*slider);
+        slider->onValueChange = [this] { parameterChanged(); };
+    }
+
+    for (auto* label : { &distortionModeLabel, &driveLabel, &distMixLabel, &filterModeLabel,
+                          &cutoffLabel, &resonanceLabel, &envAmountLabel })
+    {
+        styleLabel(*label);
+        addAndMakeVisible(*label);
+    }
+
+    cutoffLabel.setText("Cutoff", juce::dontSendNotification);
+    resonanceLabel.setText("Resonance", juce::dontSendNotification);
+    envAmountLabel.setText("Env Amount", juce::dontSendNotification);
+
+    updateSectionVisibility();
 }
 
 void EffectsPanel::paint(juce::Graphics& g)
@@ -64,67 +106,221 @@ void EffectsPanel::paint(juce::Graphics& g)
 
     g.setColour(juce::Colour(Theme::accentOrange));
     g.setFont(juce::Font(Theme::fontSectionHead).boldened());
-    g.drawText("EFFECTS", 10, 4, 100, 20, juce::Justification::centredLeft);
+    g.drawText("EFFECTS", 12, 6, 100, 18, juce::Justification::centredLeft);
 
-    // Separator between distortion and filter
-    int midY = getHeight() / 2 + 8;
-    g.setColour(juce::Colour(Theme::border));
-    g.drawHorizontalLine(midY, 8.0f, static_cast<float>(getWidth() - 8));
+    auto drawSection = [&](juce::Rectangle<int> headerBounds, juce::Rectangle<int> bodyBounds,
+                           const juce::String& title, bool enabled, bool expanded)
+    {
+        g.setColour(enabled ? juce::Colour(Theme::bgPanelHover) : juce::Colour(Theme::bgControl));
+        g.fillRoundedRectangle(headerBounds.toFloat(), Theme::cornerRadius);
+        g.setColour(enabled ? juce::Colour(Theme::borderActive) : juce::Colour(Theme::border));
+        g.drawRoundedRectangle(headerBounds.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+
+        juce::Path chevron;
+        const auto cx = static_cast<float>(headerBounds.getRight() - 14);
+        const auto cy = static_cast<float>(headerBounds.getCentreY());
+        if (expanded && enabled)
+        {
+            chevron.startNewSubPath(cx - 4.0f, cy - 2.0f);
+            chevron.lineTo(cx, cy + 2.5f);
+            chevron.lineTo(cx + 4.0f, cy - 2.0f);
+        }
+        else
+        {
+            chevron.startNewSubPath(cx - 2.0f, cy - 4.0f);
+            chevron.lineTo(cx + 2.5f, cy);
+            chevron.lineTo(cx - 2.0f, cy + 4.0f);
+        }
+
+        g.setColour(juce::Colour(Theme::textBright));
+        g.setFont(juce::Font(Theme::fontValue).boldened());
+        g.drawText(title, headerBounds.withTrimmedLeft(36).withTrimmedRight(26),
+                   juce::Justification::centredLeft, false);
+        g.strokePath(chevron, juce::PathStrokeType(1.5f, juce::PathStrokeType::curved,
+                                                   juce::PathStrokeType::rounded));
+
+        if (enabled && expanded && !bodyBounds.isEmpty())
+        {
+            g.setColour(juce::Colour(Theme::bgElevated));
+            g.fillRoundedRectangle(bodyBounds.toFloat(), Theme::cornerRadius);
+            g.setColour(juce::Colour(Theme::borderSubtle));
+            g.drawRoundedRectangle(bodyBounds.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+        }
+    };
+
+    drawSection(distortionHeaderBounds, distortionBodyBounds, "Distortion",
+                distortionToggle.getToggleState(), distortionExpanded);
+    drawSection(filterHeaderBounds, filterBodyBounds, "Filter",
+                filterToggle.getToggleState(), filterExpanded);
 }
 
 void EffectsPanel::resized()
 {
-    auto area = getLocalBounds().reduced(8);
-    area.removeFromTop(22); // Title
+    auto area = getLocalBounds().reduced(Theme::panelPadding);
+    area.removeFromTop(24);
 
-    int halfHeight = area.getHeight() / 2 - 2;
+    constexpr int headerHeight = 24;
+    const int sectionGap = Theme::sectionGap;
+    const bool showDistortionBody = distortionToggle.getToggleState() && distortionExpanded;
+    const bool showFilterBody = filterToggle.getToggleState() && filterExpanded;
+    const int availableBodyHeight = juce::jmax(0, area.getHeight() - headerHeight * 2 - sectionGap);
+    const int distortionBodyHeight = showDistortionBody && showFilterBody ? availableBodyHeight / 2 : availableBodyHeight;
+    const int filterBodyHeight = showFilterBody ? (showDistortionBody ? availableBodyHeight - distortionBodyHeight : availableBodyHeight) : 0;
 
-    // Distortion section (top)
-    auto distArea = area.removeFromTop(halfHeight).reduced(2);
+    distortionHeaderBounds = area.removeFromTop(headerHeight);
+    if (showDistortionBody)
     {
-        auto topRow = distArea.removeFromTop(24);
-        distortionToggle.setBounds(topRow.removeFromLeft(90));
-        distortionModeLabel.setBounds(topRow.removeFromLeft(35));
-        distortionModeBox.setBounds(topRow);
-
-        distArea.removeFromTop(4);
-        auto knobRow = distArea;
-        int knobW = knobRow.getWidth() / 2;
-
-        auto driveArea = knobRow.removeFromLeft(knobW);
-        driveLabel.setBounds(driveArea.removeFromTop(16));
-        driveSlider.setBounds(driveArea);
-
-        auto mixArea = knobRow;
-        distMixLabel.setBounds(mixArea.removeFromTop(16));
-        distMixSlider.setBounds(mixArea);
+        area.removeFromTop(4);
+        distortionBodyBounds = area.removeFromTop(distortionBodyHeight);
+        area.removeFromTop(sectionGap);
+    }
+    else
+    {
+        distortionBodyBounds = {};
+        area.removeFromTop(sectionGap);
     }
 
-    area.removeFromTop(4);
-
-    // Filter section (bottom)
-    auto filtArea = area.reduced(2);
+    filterHeaderBounds = area.removeFromTop(headerHeight);
+    if (showFilterBody)
     {
-        auto topRow = filtArea.removeFromTop(24);
-        filterToggle.setBounds(topRow.removeFromLeft(60));
-        filterModeLabel.setBounds(topRow.removeFromLeft(30));
-        filterModeBox.setBounds(topRow);
+        area.removeFromTop(4);
+        filterBodyBounds = area.removeFromTop(filterBodyHeight);
+    }
+    else
+    {
+        filterBodyBounds = {};
+    }
 
-        filtArea.removeFromTop(4);
-        auto knobRow = filtArea;
-        int knobW = knobRow.getWidth() / 3;
+    distortionToggle.setBounds(distortionHeaderBounds.withTrimmedLeft(8).withWidth(28));
+    filterToggle.setBounds(filterHeaderBounds.withTrimmedLeft(8).withWidth(28));
 
-        auto cutArea = knobRow.removeFromLeft(knobW);
-        cutoffLabel.setBounds(cutArea.removeFromTop(16));
-        cutoffSlider.setBounds(cutArea);
+    auto clearHidden = [](juce::Component& component)
+    {
+        component.setBounds(juce::Rectangle<int>());
+    };
 
-        auto resArea = knobRow.removeFromLeft(knobW);
-        resonanceLabel.setBounds(resArea.removeFromTop(16));
-        resonanceSlider.setBounds(resArea);
+    if (showDistortionBody)
+    {
+        auto body = distortionBodyBounds.reduced(10, 10);
+        const int labelH = 14;
+        const int comboH = 24;
+        const int knobH = Theme::knobSize + 18;
+        const int comboWidth = juce::jmax(80, body.getWidth() / 3);
+        auto left = body.removeFromLeft(comboWidth);
+        body.removeFromLeft(Theme::controlGap);
+        auto driveArea = body.removeFromLeft((body.getWidth() - Theme::controlGap) / 2);
+        body.removeFromLeft(Theme::controlGap);
+        auto mixArea = body;
 
-        auto envArea = knobRow;
-        envAmountLabel.setBounds(envArea.removeFromTop(16));
-        envAmountSlider.setBounds(envArea);
+        distortionModeLabel.setBounds(left.removeFromTop(labelH));
+        distortionModeBox.setBounds(left.removeFromTop(comboH));
+        driveLabel.setBounds(driveArea.removeFromTop(labelH));
+        driveSlider.setBounds(driveArea.removeFromTop(knobH));
+        distMixLabel.setBounds(mixArea.removeFromTop(labelH));
+        distMixSlider.setBounds(mixArea.removeFromTop(knobH));
+    }
+    else
+    {
+        clearHidden(distortionModeLabel);
+        clearHidden(distortionModeBox);
+        clearHidden(driveLabel);
+        clearHidden(driveSlider);
+        clearHidden(distMixLabel);
+        clearHidden(distMixSlider);
+    }
+
+    if (showFilterBody)
+    {
+        auto body = filterBodyBounds.reduced(10, 10);
+        const int labelH = 14;
+        const int comboH = 24;
+        const int largeKnobH = Theme::knobSizeLarge + 18;
+        const int knobH = Theme::knobSize + 18;
+
+        filterModeLabel.setBounds(body.removeFromTop(labelH));
+        filterModeBox.setBounds(body.removeFromTop(comboH));
+        body.removeFromTop(6);
+
+        const int firstKnobWidth = juce::jmax(72, body.getWidth() / 3 + 10);
+        auto cutoffArea = body.removeFromLeft(firstKnobWidth);
+        body.removeFromLeft(Theme::controlGap);
+        auto resonanceArea = body.removeFromLeft((body.getWidth() - Theme::controlGap) / 2);
+        body.removeFromLeft(Theme::controlGap);
+        auto envArea = body;
+
+        cutoffLabel.setBounds(cutoffArea.removeFromTop(labelH));
+        cutoffSlider.setBounds(cutoffArea.removeFromTop(largeKnobH));
+        resonanceLabel.setBounds(resonanceArea.removeFromTop(labelH));
+        resonanceSlider.setBounds(resonanceArea.removeFromTop(knobH));
+        envAmountLabel.setBounds(envArea.removeFromTop(labelH));
+        envAmountSlider.setBounds(envArea.removeFromTop(knobH));
+    }
+    else
+    {
+        clearHidden(filterModeLabel);
+        clearHidden(filterModeBox);
+        clearHidden(cutoffLabel);
+        clearHidden(cutoffSlider);
+        clearHidden(resonanceLabel);
+        clearHidden(resonanceSlider);
+        clearHidden(envAmountLabel);
+        clearHidden(envAmountSlider);
+    }
+}
+
+void EffectsPanel::mouseUp(const juce::MouseEvent& event)
+{
+    if (distortionHeaderBounds.contains(event.getPosition()) && !distortionToggle.getBounds().contains(event.getPosition()))
+    {
+        distortionExpanded = !distortionExpanded;
+        updateSectionVisibility();
+        resized();
+        repaint();
+        return;
+    }
+
+    if (filterHeaderBounds.contains(event.getPosition()) && !filterToggle.getBounds().contains(event.getPosition()))
+    {
+        filterExpanded = !filterExpanded;
+        updateSectionVisibility();
+        resized();
+        repaint();
+    }
+}
+
+void EffectsPanel::mouseMove(const juce::MouseEvent& event)
+{
+    if (distortionHeaderBounds.contains(event.getPosition()) || filterHeaderBounds.contains(event.getPosition()))
+        setMouseCursor(juce::MouseCursor::PointingHandCursor);
+    else
+        setMouseCursor(juce::MouseCursor::NormalCursor);
+}
+
+void EffectsPanel::updateSectionVisibility()
+{
+    const bool showDistortionBody = distortionToggle.getToggleState() && distortionExpanded;
+    const bool showFilterBody = filterToggle.getToggleState() && filterExpanded;
+
+    for (auto* component : { static_cast<juce::Component*>(&distortionModeBox),
+                             static_cast<juce::Component*>(&distortionModeLabel),
+                             static_cast<juce::Component*>(&driveSlider),
+                             static_cast<juce::Component*>(&driveLabel),
+                             static_cast<juce::Component*>(&distMixSlider),
+                             static_cast<juce::Component*>(&distMixLabel) })
+    {
+        component->setVisible(showDistortionBody);
+    }
+
+    for (auto* component : { static_cast<juce::Component*>(&filterModeBox),
+                             static_cast<juce::Component*>(&filterModeLabel),
+                             static_cast<juce::Component*>(&cutoffSlider),
+                             static_cast<juce::Component*>(&cutoffLabel),
+                             static_cast<juce::Component*>(&resonanceSlider),
+                             static_cast<juce::Component*>(&resonanceLabel),
+                             static_cast<juce::Component*>(&envAmountSlider),
+                             static_cast<juce::Component*>(&envAmountLabel) })
+    {
+        component->setVisible(showFilterBody);
     }
 }
 

--- a/Source/UI/EffectsPanel.h
+++ b/Source/UI/EffectsPanel.h
@@ -21,6 +21,8 @@ public:
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+    void mouseUp(const juce::MouseEvent& event) override;
+    void mouseMove(const juce::MouseEvent& event) override;
 
     // Distortion accessors
     bool getDistortionEnabled() const;
@@ -40,6 +42,7 @@ public:
 
 private:
     void parameterChanged();
+    void updateSectionVisibility();
 
     // Distortion controls
     juce::ToggleButton distortionToggle { "Distortion" };
@@ -65,6 +68,13 @@ private:
 
     juce::Slider envAmountSlider;
     juce::Label envAmountLabel { {}, "Env Amt" };
+
+    bool distortionExpanded = true;
+    bool filterExpanded = true;
+    juce::Rectangle<int> distortionHeaderBounds;
+    juce::Rectangle<int> distortionBodyBounds;
+    juce::Rectangle<int> filterHeaderBounds;
+    juce::Rectangle<int> filterBodyBounds;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EffectsPanel)
 };

--- a/Source/UI/GrainHexLookAndFeel.h
+++ b/Source/UI/GrainHexLookAndFeel.h
@@ -11,22 +11,31 @@ namespace grainhex {
 struct Theme
 {
     // Background colours (darkest to lightest)
-    static constexpr uint32_t bgDarkest    = 0xff0a0a16;
-    static constexpr uint32_t bgDark       = 0xff0d0d1a;
-    static constexpr uint32_t bgPanel      = 0xff12122a;
-    static constexpr uint32_t bgControl    = 0xff1a1a2e;
-    static constexpr uint32_t bgHover      = 0xff222244;
+    static constexpr uint32_t bgDarkest    = 0xff08080f;
+    static constexpr uint32_t bgDark       = 0xff0c0c14;
+    static constexpr uint32_t bgPanel      = 0xff141428;
+    static constexpr uint32_t bgPanelHover = 0xff1a1a34;
+    static constexpr uint32_t bgControl    = 0xff1c1c32;
+    static constexpr uint32_t bgHover      = 0xff252548;
+    static constexpr uint32_t bgElevated   = 0xff1e1e3a;
 
     // Border / separator
-    static constexpr uint32_t border       = 0xff333355;
-    static constexpr uint32_t borderActive = 0xff555588;
+    static constexpr uint32_t border       = 0xff2a2a44;
+    static constexpr uint32_t borderActive = 0xff4a4a77;
+    static constexpr uint32_t borderSubtle = 0xff1e1e36;
 
     // Accent colours
-    static constexpr uint32_t accentGreen  = 0xff16c784;  // Primary — granular, resample
-    static constexpr uint32_t accentPurple = 0xffcc66ff;  // Sub tuner
-    static constexpr uint32_t accentRed    = 0xffff6b6b;  // Modulation
-    static constexpr uint32_t accentCyan   = 0xff00ccff;  // Loop markers, info
-    static constexpr uint32_t accentOrange = 0xffff9933;  // Effects / browser
+    static constexpr uint32_t accentGreen  = 0xff14b876;  // Primary — granular, resample
+    static constexpr uint32_t accentPurple = 0xffb366e6;  // Sub tuner
+    static constexpr uint32_t accentRed    = 0xffee6666;  // Modulation / warning
+    static constexpr uint32_t accentCyan   = 0xff00bbee;  // Loop markers, info
+    static constexpr uint32_t accentOrange = 0xffee8833;  // Effects / browser
+
+    // Semantic button colours
+    static constexpr uint32_t buttonPrimary     = 0xff14b876;
+    static constexpr uint32_t buttonSecondary   = 0xff2a2a4a;
+    static constexpr uint32_t buttonDestructive = 0xffee6666;
+    static constexpr uint32_t buttonUtility     = 0xff1c1c32;
 
     // Text
     static constexpr uint32_t textBright   = 0xffe0e0e8;
@@ -35,17 +44,21 @@ struct Theme
     static constexpr uint32_t textMuted    = 0xff505068;
 
     // Typography sizes
-    static constexpr float fontTitle       = 24.0f;
-    static constexpr float fontSectionHead = 13.0f;
-    static constexpr float fontLabel       = 11.0f;
-    static constexpr float fontSmall       = 10.0f;
-    static constexpr float fontValue       = 12.0f;
+    static constexpr float fontTitle       = 22.0f;
+    static constexpr float fontSectionHead = 12.0f;
+    static constexpr float fontLabel       = 10.5f;
+    static constexpr float fontSmall       = 9.5f;
+    static constexpr float fontValue       = 11.0f;
+    static constexpr float fontMetadata    = 9.0f;
 
     // Geometry
-    static constexpr float cornerRadius    = 6.0f;
-    static constexpr float borderWidth     = 1.0f;
-    static constexpr int   panelPadding    = 8;
-    static constexpr int   controlGap      = 4;
+    static constexpr float cornerRadius    = 8.0f;
+    static constexpr float borderWidth     = 0.5f;
+    static constexpr int   panelPadding    = 10;
+    static constexpr int   controlGap      = 6;
+    static constexpr int   sectionGap      = 8;
+    static constexpr int   knobSize        = 48;
+    static constexpr int   knobSizeLarge   = 56;
 };
 
 /**
@@ -76,7 +89,7 @@ public:
         setColour(juce::TextButton::buttonColourId,          juce::Colour(Theme::bgControl));
         setColour(juce::TextButton::buttonOnColourId,        juce::Colour(Theme::accentGreen));
         setColour(juce::TextButton::textColourOnId,          juce::Colour(Theme::bgDarkest));
-        setColour(juce::TextButton::textColourOffId,         juce::Colour(Theme::textNormal));
+        setColour(juce::TextButton::textColourOffId,         juce::Colour(Theme::textBright));
 
         // Toggle buttons
         setColour(juce::ToggleButton::textColourId,          juce::Colour(Theme::textNormal));
@@ -113,18 +126,26 @@ public:
         bgArc.addCentredArc(centreX, centreY, radius, radius, 0.0f,
                             rotaryStartAngle, rotaryEndAngle, true);
         g.setColour(juce::Colour(Theme::border));
-        g.strokePath(bgArc, juce::PathStrokeType(3.0f));
+        g.strokePath(bgArc, juce::PathStrokeType(3.5f, juce::PathStrokeType::curved,
+                                                 juce::PathStrokeType::rounded));
 
         // Value arc
         juce::Path valueArc;
         valueArc.addCentredArc(centreX, centreY, radius, radius, 0.0f,
                                rotaryStartAngle, angle, true);
         auto fillColour = slider.findColour(juce::Slider::rotarySliderFillColourId);
+        if (slider.isMouseOverOrDragging())
+            fillColour = fillColour.brighter(0.15f);
+
+        g.setColour(fillColour.withAlpha(0.18f));
+        g.strokePath(valueArc, juce::PathStrokeType(6.0f, juce::PathStrokeType::curved,
+                                                    juce::PathStrokeType::rounded));
         g.setColour(fillColour);
-        g.strokePath(valueArc, juce::PathStrokeType(3.0f));
+        g.strokePath(valueArc, juce::PathStrokeType(3.5f, juce::PathStrokeType::curved,
+                                                    juce::PathStrokeType::rounded));
 
         // Thumb dot
-        auto thumbRadius = 4.0f;
+        auto thumbRadius = 5.0f;
         auto thumbX = centreX + (radius - 2.0f) * std::cos(angle - juce::MathConstants<float>::halfPi);
         auto thumbY = centreY + (radius - 2.0f) * std::sin(angle - juce::MathConstants<float>::halfPi);
         g.setColour(juce::Colour(Theme::textBright));
@@ -145,10 +166,20 @@ public:
             baseColour = baseColour.brighter(0.1f);
 
         g.setColour(baseColour);
-        g.fillRoundedRectangle(bounds, 4.0f);
+        g.fillRoundedRectangle(bounds, Theme::cornerRadius);
 
         g.setColour(juce::Colour(Theme::border));
-        g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
+        g.drawRoundedRectangle(bounds, Theme::cornerRadius, 1.0f);
+
+        const auto primaryGreen = juce::Colour(Theme::buttonPrimary);
+        const auto primaryOrange = juce::Colour(Theme::accentOrange);
+        const auto destructive = juce::Colour(Theme::buttonDestructive);
+        if (backgroundColour == primaryGreen || backgroundColour == primaryOrange || backgroundColour == destructive)
+        {
+            auto accentColour = backgroundColour.brighter(0.1f);
+            g.setColour(accentColour);
+            g.fillRoundedRectangle(bounds.removeFromBottom(2.0f), Theme::cornerRadius);
+        }
     }
 
     void drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height,
@@ -158,7 +189,7 @@ public:
         if (style == juce::Slider::LinearHorizontal)
         {
             auto trackY = static_cast<float>(y + height / 2);
-            auto trackHeight = 4.0f;
+            auto trackHeight = 5.0f;
 
             // Track background
             g.setColour(juce::Colour(Theme::border));
@@ -172,13 +203,100 @@ public:
 
             // Thumb
             g.setColour(juce::Colour(Theme::textBright));
-            g.fillEllipse(sliderPos - 5.0f, trackY - 5.0f, 10.0f, 10.0f);
+            if (slider.isMouseOverOrDragging())
+                g.setColour(juce::Colour(Theme::textBright).brighter(0.2f));
+            g.fillEllipse(sliderPos - 6.0f, trackY - 6.0f, 12.0f, 12.0f);
         }
         else
         {
             LookAndFeel_V4::drawLinearSlider(g, x, y, width, height, sliderPos,
                                              minSliderPos, maxSliderPos, style, slider);
         }
+    }
+
+    void drawToggleButton(juce::Graphics& g, juce::ToggleButton& button,
+                          bool shouldDrawButtonAsHighlighted,
+                          bool shouldDrawButtonAsDown) override
+    {
+        auto bounds = button.getLocalBounds().toFloat();
+        auto indicatorSize = juce::jmin(16.0f, bounds.getHeight() - 4.0f);
+        auto indicator = juce::Rectangle<float>(bounds.getX() + 2.0f,
+                                                bounds.getCentreY() - indicatorSize * 0.5f,
+                                                indicatorSize,
+                                                indicatorSize);
+
+        auto accent = button.findColour(juce::ToggleButton::tickColourId);
+        auto outline = shouldDrawButtonAsHighlighted ? accent.brighter(0.15f) : juce::Colour(Theme::borderActive);
+        auto fill = button.getToggleState() ? accent : juce::Colour(Theme::bgControl);
+
+        if (shouldDrawButtonAsDown)
+            fill = fill.brighter(0.1f);
+
+        g.setColour(fill);
+        g.fillEllipse(indicator);
+        g.setColour(button.getToggleState() ? accent.brighter(0.1f) : outline);
+        g.drawEllipse(indicator, 1.5f);
+
+        if (button.getToggleState())
+        {
+            g.setColour(juce::Colour(Theme::textBright).withAlpha(0.9f));
+            g.fillEllipse(indicator.reduced(indicatorSize * 0.28f));
+        }
+
+        auto textBounds = bounds.withX(indicator.getRight() + 8.0f);
+        g.setColour(button.isEnabled() ? juce::Colour(Theme::textNormal)
+                                       : juce::Colour(Theme::textMuted));
+        g.setFont(juce::Font(Theme::fontValue, juce::Font::plain));
+        g.drawFittedText(button.getButtonText(),
+                         textBounds.toNearestInt(),
+                         juce::Justification::centredLeft, 1);
+    }
+
+    void drawComboBox(juce::Graphics& g, int width, int height, bool isButtonDown,
+                      int buttonX, int buttonY, int buttonW, int buttonH,
+                      juce::ComboBox& box) override
+    {
+        juce::ignoreUnused(buttonY, buttonH);
+
+        auto bounds = juce::Rectangle<float>(0.5f, 0.5f, static_cast<float>(width) - 1.0f,
+                                             static_cast<float>(height) - 1.0f);
+        auto bg = juce::Colour(Theme::bgControl);
+        if (box.isMouseOver(true))
+            bg = juce::Colour(Theme::bgPanelHover);
+        if (isButtonDown)
+            bg = bg.brighter(0.08f);
+
+        g.setColour(bg);
+        g.fillRoundedRectangle(bounds, Theme::cornerRadius);
+
+        g.setColour(box.isMouseOver(true) ? juce::Colour(Theme::borderActive) : juce::Colour(Theme::border));
+        g.drawRoundedRectangle(bounds, Theme::cornerRadius, 1.0f);
+
+        juce::Path arrow;
+        const auto centreX = static_cast<float>(buttonX + buttonW / 2);
+        const auto centreY = static_cast<float>(height) * 0.5f;
+        arrow.startNewSubPath(centreX - 4.0f, centreY - 1.5f);
+        arrow.lineTo(centreX, centreY + 3.0f);
+        arrow.lineTo(centreX + 4.0f, centreY - 1.5f);
+        g.setColour(juce::Colour(Theme::textDim));
+        g.strokePath(arrow, juce::PathStrokeType(1.5f, juce::PathStrokeType::curved,
+                                                 juce::PathStrokeType::rounded));
+    }
+
+    void positionComboBoxText(juce::ComboBox& box, juce::Label& label) override
+    {
+        label.setBounds(10, 1, box.getWidth() - 28, box.getHeight() - 2);
+        label.setFont(getComboBoxFont(box));
+    }
+
+    juce::Font getComboBoxFont(juce::ComboBox&) override
+    {
+        return juce::Font(Theme::fontValue);
+    }
+
+    juce::Font getTextButtonFont(juce::TextButton&, int buttonHeight) override
+    {
+        return juce::Font(juce::jmin(Theme::fontValue, static_cast<float>(buttonHeight) * 0.42f)).boldened();
     }
 };
 

--- a/Source/UI/GranularPanel.cpp
+++ b/Source/UI/GranularPanel.cpp
@@ -5,7 +5,7 @@ namespace grainhex {
 static void styleRotarySlider(juce::Slider& slider, double min, double max, double defaultVal, double interval = 0.0)
 {
     slider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-    slider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 60, 16);
+    slider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 64, 16);
     slider.setRange(min, max, interval);
     slider.setValue(defaultVal, juce::dontSendNotification);
     slider.setColour(juce::Slider::rotarySliderFillColourId, juce::Colour(Theme::accentGreen));
@@ -111,67 +111,100 @@ void GranularPanel::paint(juce::Graphics& g)
 
     g.setColour(juce::Colour(Theme::accentGreen));
     g.setFont(juce::Font(Theme::fontSectionHead).boldened());
-    g.drawText("GRANULAR", 10, 4, 120, 20, juce::Justification::centredLeft);
+    g.drawText("GRANULAR", 12, 6, 120, 18, juce::Justification::centredLeft);
+
+    auto drawGroup = [&](juce::Rectangle<int> bounds, const juce::String& title)
+    {
+        g.setColour(juce::Colour(Theme::bgControl));
+        g.fillRoundedRectangle(bounds.toFloat(), Theme::cornerRadius);
+        g.setColour(juce::Colour(Theme::borderSubtle));
+        g.drawRoundedRectangle(bounds.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+        g.setColour(juce::Colour(Theme::textDim));
+        g.setFont(juce::Font(Theme::fontSmall).boldened());
+        g.drawText(title, bounds.getX() + 10, bounds.getY() + 8, bounds.getWidth() - 20, 14,
+                   juce::Justification::centredLeft);
+    };
+
+    drawGroup(coreGroupBounds, "Core");
+    drawGroup(scatterGroupBounds, "Scatter");
+    drawGroup(tuningGroupBounds, "Tuning");
 }
 
 void GranularPanel::resized()
 {
-    auto area = getLocalBounds().reduced(8);
-    area.removeFromTop(22); // Header space
+    auto area = getLocalBounds().reduced(Theme::panelPadding);
+    area.removeFromTop(26);
 
-    const int knobW = 75;
-    const int knobH = 75;
-    const int labelH = 16;
-    const int comboH = 24;
-    const int comboW = 90;
-    const int gap = 4;
+    const int groupGap = Theme::sectionGap;
+    const int groupWidth = (area.getWidth() - groupGap * 2) / 3;
+    coreGroupBounds = area.removeFromLeft(groupWidth);
+    area.removeFromLeft(groupGap);
+    scatterGroupBounds = area.removeFromLeft(groupWidth);
+    area.removeFromLeft(groupGap);
+    tuningGroupBounds = area;
 
-    // Row 1: Size, Count, Position, Spray, Pitch, Spread (6 knobs)
-    auto row1 = area.removeFromTop(knobH + labelH + gap);
-    int numKnobs = 6;
-    int totalKnobWidth = numKnobs * knobW;
-    int spacing = (row1.getWidth() - totalKnobWidth) / (numKnobs - 1);
-    spacing = std::max(spacing, 2);
-
-    struct KnobPair { juce::Slider* slider; juce::Label* label; };
-    KnobPair knobs[] = {
-        { &grainSizeSlider, &grainSizeLabel },
-        { &grainCountSlider, &grainCountLabel },
-        { &positionSlider, &positionLabel },
-        { &spraySlider, &sprayLabel },
-        { &pitchSlider, &pitchLabel },
-        { &spreadSlider, &spreadLabel }
+    auto layoutGroup = [](juce::Rectangle<int> bounds)
+    {
+        bounds.reduce(10, 10);
+        bounds.removeFromTop(18);
+        return bounds;
     };
 
-    int xPos = row1.getX();
-    for (auto& kp : knobs)
+    auto core = layoutGroup(coreGroupBounds);
+    auto scatter = layoutGroup(scatterGroupBounds);
+    auto tuning = layoutGroup(tuningGroupBounds);
+
+    const int labelH = 14;
+    const int comboH = 24;
+    const int smallKnob = Theme::knobSize;
+    const int largeKnob = Theme::knobSizeLarge;
+    const int sliderValueH = 18;
+
     {
-        kp.label->setBounds(xPos, row1.getY(), knobW, labelH);
-        kp.slider->setBounds(xPos, row1.getY() + labelH, knobW, knobH);
-        xPos += knobW + spacing;
+        auto topRow = core.removeFromTop(labelH + smallKnob + sliderValueH + 8);
+        auto sizeArea = topRow.removeFromLeft((topRow.getWidth() - Theme::controlGap) / 2);
+        topRow.removeFromLeft(Theme::controlGap);
+        auto countArea = topRow;
+
+        grainSizeLabel.setBounds(sizeArea.removeFromTop(labelH));
+        grainSizeSlider.setBounds(sizeArea.removeFromTop(smallKnob + sliderValueH));
+
+        grainCountLabel.setBounds(countArea.removeFromTop(labelH));
+        grainCountSlider.setBounds(countArea.removeFromTop(smallKnob + sliderValueH));
+
+        core.removeFromTop(2);
+        windowShapeLabel.setBounds(core.removeFromTop(labelH));
+        windowShapeBox.setBounds(core.removeFromTop(comboH));
     }
 
-    area.removeFromTop(gap);
-
-    // Row 2: Combo boxes (Quantize, Window, Direction)
-    auto row2 = area.removeFromTop(comboH + labelH + gap);
-
-    struct ComboPair { juce::ComboBox* box; juce::Label* label; };
-    ComboPair combos[] = {
-        { &pitchQuantizeBox, &pitchQuantizeLabel },
-        { &windowShapeBox, &windowShapeLabel },
-        { &directionBox, &directionLabel }
-    };
-
-    int comboSpacing = (row2.getWidth() - 3 * comboW) / 4;
-    comboSpacing = std::max(comboSpacing, 8);
-    int cx = row2.getX() + comboSpacing;
-
-    for (auto& cp : combos)
     {
-        cp.label->setBounds(cx, row2.getY(), comboW, labelH);
-        cp.box->setBounds(cx, row2.getY() + labelH, comboW, comboH);
-        cx += comboW + comboSpacing;
+        auto positionArea = scatter.removeFromTop(labelH + largeKnob + sliderValueH + 8);
+        positionLabel.setBounds(positionArea.removeFromTop(labelH));
+        positionSlider.setBounds(positionArea.removeFromTop(largeKnob + sliderValueH));
+
+        scatter.removeFromTop(2);
+        auto lowerRow = scatter.removeFromTop(labelH + smallKnob + sliderValueH + 4);
+        sprayLabel.setBounds(lowerRow.removeFromTop(labelH));
+        spraySlider.setBounds(lowerRow.removeFromTop(smallKnob + sliderValueH));
+
+        scatter.removeFromTop(2);
+        directionLabel.setBounds(scatter.removeFromTop(labelH));
+        directionBox.setBounds(scatter.removeFromTop(comboH));
+    }
+
+    {
+        auto pitchArea = tuning.removeFromTop(labelH + largeKnob + sliderValueH + 8);
+        pitchLabel.setBounds(pitchArea.removeFromTop(labelH));
+        pitchSlider.setBounds(pitchArea.removeFromTop(largeKnob + sliderValueH));
+
+        tuning.removeFromTop(2);
+        auto lowerRow = tuning.removeFromTop(labelH + smallKnob + sliderValueH + 4);
+        spreadLabel.setBounds(lowerRow.removeFromTop(labelH));
+        spreadSlider.setBounds(lowerRow.removeFromTop(smallKnob + sliderValueH));
+
+        tuning.removeFromTop(2);
+        pitchQuantizeLabel.setBounds(tuning.removeFromTop(labelH));
+        pitchQuantizeBox.setBounds(tuning.removeFromTop(comboH));
     }
 }
 

--- a/Source/UI/GranularPanel.h
+++ b/Source/UI/GranularPanel.h
@@ -62,6 +62,10 @@ private:
     juce::Label windowShapeLabel   { {}, "Window" };
     juce::Label directionLabel     { {}, "Direction" };
 
+    juce::Rectangle<int> coreGroupBounds;
+    juce::Rectangle<int> scatterGroupBounds;
+    juce::Rectangle<int> tuningGroupBounds;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GranularPanel)
 };
 

--- a/Source/UI/MainEditor.cpp
+++ b/Source/UI/MainEditor.cpp
@@ -108,6 +108,7 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
 
     addAndMakeVisible(modulationPanel);
     modulationPanel.setVisible(false);
+    modulationPanel.setBPM(120.0f);
     modulationPanel.onParameterChanged = [this] { pushModulationParams(); };
 
     // === BOTTOM-RIGHT: Resample panel ===
@@ -383,9 +384,11 @@ void MainEditor::filesDropped(const juce::StringArray& files, int /*x*/, int /*y
 
 void MainEditor::loadFile(const juce::File& file)
 {
-    updateStatusLabel("Loading: " + file.getFileName() + "...");
+    const auto extension = file.getFileExtension().toLowerCase();
+    const bool wavImport = extension == ".wav" || extension == ".wave";
+    updateStatusLabel((wavImport ? "Importing WAV: " : "Loading sample: ") + file.getFileName() + "...");
 
-    sampleManager.loadFileAsync(file, [this](bool success, const juce::String& message)
+    sampleManager.loadFileAsync(file, [this, wavImport](bool success, const juce::String& message)
     {
         if (success)
         {
@@ -410,6 +413,12 @@ void MainEditor::loadFile(const juce::File& file)
             setSampleInfoText(info);
             sampleBrowser.clearLoadedSample();
             updateTransportButtons();
+
+            updateStatusLabel((wavImport ? "Imported WAV: " : "Loaded sample: ")
+                              + meta.filename
+                              + " | Root: " + meta.rootNote.getNoteName()
+                              + " (" + juce::String(meta.rootNote.confidence * 100.0f, 0) + "% confidence)");
+            return;
         }
 
         updateStatusLabel(message);
@@ -518,11 +527,15 @@ void MainEditor::pushEffectsParams()
 void MainEditor::pushModulationParams()
 {
     auto& me = audioEngine.getModulationEngine();
+    const auto syncDivision = modulationPanel.getLFOSyncDivision();
 
     me.getLFO().setEnabled(modulationPanel.getLFOEnabled());
     me.getLFO().setShape(modulationPanel.getLFOShape());
     me.getLFO().setRate(modulationPanel.getLFORate());
     me.getLFO().setDepth(modulationPanel.getLFODepth());
+    me.getLFO().setTempoSync(syncDivision > 0.0f,
+                             modulationPanel.getBPM(),
+                             syncDivision > 0.0f ? syncDivision : 1.0f);
 
     me.getEnvelope().setEnabled(modulationPanel.getEnvelopeEnabled());
     me.getEnvelope().setAttack(modulationPanel.getAttack());

--- a/Source/UI/MainEditor.cpp
+++ b/Source/UI/MainEditor.cpp
@@ -29,8 +29,6 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
 
     // Transport buttons
     addAndMakeVisible(playButton);
-    playButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::accentGreen));
-    playButton.setColour(juce::TextButton::textColourOffId, juce::Colour(Theme::bgDarkest));
     playButton.onClick = [this]
     {
         audioEngine.setSineTestEnabled(false);
@@ -39,6 +37,7 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
     };
 
     addAndMakeVisible(stopButton);
+    stopButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonSecondary));
     stopButton.onClick = [this]
     {
         audioEngine.stop();
@@ -46,10 +45,13 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
     };
 
     addAndMakeVisible(loadButton);
+    loadButton.setButtonText("Import WAV");
+    loadButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::accentOrange));
+    loadButton.setColour(juce::TextButton::textColourOffId, juce::Colour(Theme::bgDarkest));
     loadButton.onClick = [this]
     {
         auto chooser = std::make_shared<juce::FileChooser>(
-            "Load Sample", juce::File{}, sampleManager.getSupportedFormatsWildcard());
+            "Import WAV or Audio Sample", juce::File{}, sampleManager.getSupportedFormatsWildcard());
         chooser->launchAsync(juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
             [this, chooser](const juce::FileChooser& fc)
             {
@@ -61,6 +63,7 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
 
     addAndMakeVisible(loopButton);
     loopButton.setToggleState(true, juce::dontSendNotification);
+    loopButton.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentCyan));
     loopButton.onClick = [this] { audioEngine.setLoopEnabled(loopButton.getToggleState()); };
 
     addAndMakeVisible(granularToggle);
@@ -80,17 +83,13 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
     addAndMakeVisible(rootNoteLabel);
     rootNoteLabel.setJustificationType(juce::Justification::centredRight);
     rootNoteLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::accentCyan));
-    rootNoteLabel.setFont(juce::Font(18.0f).boldened());
+    rootNoteLabel.setFont(juce::Font(Theme::fontValue).boldened());
+    rootNoteLabel.setText("Root --", juce::dontSendNotification);
 
     addAndMakeVisible(sampleInfoLabel);
     sampleInfoLabel.setJustificationType(juce::Justification::centredLeft);
     sampleInfoLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textDim));
-
-    addAndMakeVisible(midiActivityLabel);
-    midiActivityLabel.setText("MIDI", juce::dontSendNotification);
-    midiActivityLabel.setJustificationType(juce::Justification::centred);
-    midiActivityLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textMuted));
-    midiActivityLabel.setFont(juce::Font(11.0f));
+    sampleInfoLabel.setFont(juce::Font(Theme::fontMetadata));
 
     // === CENTER: Granular panel ===
     addAndMakeVisible(granularPanel);
@@ -129,29 +128,36 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
     volumeSlider.setValue(0.8, juce::dontSendNotification);
     volumeSlider.setSliderStyle(juce::Slider::LinearHorizontal);
     volumeSlider.setTextBoxStyle(juce::Slider::NoTextBox, true, 0, 0);
+    volumeSlider.setColour(juce::Slider::thumbColourId, juce::Colour(Theme::accentGreen));
     volumeSlider.onValueChange = [this]
     {
         audioEngine.setMasterVolume(static_cast<float>(volumeSlider.getValue()));
     };
     addAndMakeVisible(volumeLabel);
     volumeLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textDim));
-    volumeLabel.setFont(juce::Font(11.0f));
+    volumeLabel.setFont(juce::Font(Theme::fontMetadata));
 
     addAndMakeVisible(monoLockToggle);
     monoLockToggle.setToggleState(false, juce::dontSendNotification);
+    monoLockToggle.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentGreen));
     monoLockToggle.onClick = [this]
     {
         audioEngine.setMonoLock(monoLockToggle.getToggleState());
     };
 
     addAndMakeVisible(exportButton);
+    exportButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonPrimary));
+    exportButton.setColour(juce::TextButton::textColourOffId, juce::Colour(Theme::bgDarkest));
     exportButton.onClick = [this] { handleExportCurrent(); };
 
     addAndMakeVisible(statusLabel);
     statusLabel.setJustificationType(juce::Justification::centredLeft);
-    statusLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textDim));
-    statusLabel.setFont(juce::Font(11.0f));
+    statusLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textBright));
+    statusLabel.setFont(juce::Font(Theme::fontMetadata).boldened());
+    statusLabel.setInterceptsMouseClicks(false, false);
+    statusLabel.setVisible(false);
 
+    setSampleInfoText("Drop a WAV file, import one, or pick a factory sample");
     updateStatusLabel("Drop a sample or pick one from the browser");
     updateTransportButtons();
 
@@ -201,14 +207,38 @@ void MainEditor::paint(juce::Graphics& g)
 {
     g.fillAll(juce::Colour(Theme::bgDark));
 
-    // Title bar
-    g.setColour(juce::Colour(Theme::accentGreen));
+    if (!transportBarBounds.isEmpty())
+    {
+        auto transport = transportBarBounds.toFloat();
+        g.setColour(juce::Colour(Theme::bgPanel));
+        g.fillRoundedRectangle(transport, Theme::cornerRadius);
+        g.setColour(juce::Colour(Theme::borderSubtle));
+        g.drawLine(transport.getX(), transport.getY(), transport.getRight(), transport.getY(), 1.0f);
+        g.drawLine(transport.getX(), transport.getBottom(), transport.getRight(), transport.getBottom(), 1.0f);
+        g.drawLine(static_cast<float>(loadButton.getX() - 10), transport.getY() + 6.0f,
+                   static_cast<float>(loadButton.getX() - 10), transport.getBottom() - 6.0f, 1.0f);
+    }
+
+    if (!footerBarBounds.isEmpty())
+    {
+        auto footer = footerBarBounds.toFloat();
+        g.setColour(juce::Colour(Theme::bgPanel));
+        g.fillRoundedRectangle(footer, Theme::cornerRadius);
+        g.setColour(juce::Colour(Theme::borderSubtle));
+        g.drawLine(footer.getX(), footer.getY(), footer.getRight(), footer.getY(), 1.0f);
+    }
+
+    g.setColour(juce::Colour(Theme::textBright));
     g.setFont(juce::Font(Theme::fontTitle).boldened());
     g.drawText("GrainHex", 12, 6, 160, 30, juce::Justification::centredLeft);
 
     g.setColour(juce::Colour(Theme::textMuted));
-    g.setFont(juce::Font(Theme::fontLabel));
-    g.drawText("v1.0", 130, 14, 50, 18, juce::Justification::centredLeft);
+    g.setFont(juce::Font(Theme::fontMetadata));
+    g.drawText("v1.0", 132, 13, 48, 18, juce::Justification::centredLeft);
+
+    g.setColour(midiIndicatorActive ? juce::Colour(Theme::accentGreen)
+                                    : juce::Colour(Theme::textMuted));
+    g.fillEllipse(midiIndicatorBounds.toFloat());
 
     // Update playhead and grain positions
     waveformView.setPlayheadPosition(audioEngine.getPlayheadPosition());
@@ -220,36 +250,38 @@ void MainEditor::paint(juce::Graphics& g)
 
 void MainEditor::resized()
 {
-    auto area = getLocalBounds().reduced(8);
+    auto area = getLocalBounds().reduced(10);
 
-    // === TITLE BAR (40px) ===
-    auto titleBar = area.removeFromTop(36);
-    // Root note + MIDI indicator on right
-    midiActivityLabel.setBounds(titleBar.removeFromRight(40));
-    rootNoteLabel.setBounds(titleBar.removeFromRight(100));
+    // === TITLE BAR (32px) ===
+    auto titleBar = area.removeFromTop(32);
+    titleBarBounds = titleBar;
+    auto titleRight = titleBar.removeFromRight(150);
+    midiIndicatorBounds = titleRight.removeFromRight(16).withSizeKeepingCentre(10, 10);
+    titleRight.removeFromRight(8);
+    rootNoteLabel.setBounds(titleRight.removeFromRight(120));
 
-    area.removeFromTop(4);
+    area.removeFromTop(Theme::sectionGap);
 
     // === FOOTER (36px) ===
-    auto footer = area.removeFromBottom(32);
-    volumeLabel.setBounds(footer.removeFromLeft(42));
-    volumeSlider.setBounds(footer.removeFromLeft(120));
-    footer.removeFromLeft(8);
-    monoLockToggle.setBounds(footer.removeFromLeft(65));
-    footer.removeFromLeft(8);
-    exportButton.setBounds(footer.removeFromLeft(85));
-    footer.removeFromLeft(12);
+    footerBarBounds = area.removeFromBottom(36);
+    auto footer = footerBarBounds.reduced(10, 4);
+    auto exportZone = footer.removeFromRight(122);
+    exportButton.setBounds(exportZone);
+    footer.removeFromRight(12);
+
+    auto centreZone = footer.removeFromRight(250);
+    volumeLabel.setBounds(centreZone.removeFromLeft(48));
+    volumeSlider.setBounds(centreZone.removeFromLeft(128));
+    centreZone.removeFromLeft(10);
+    monoLockToggle.setBounds(centreZone.removeFromLeft(76));
+
+    sampleInfoLabel.setBounds(footer);
     statusLabel.setBounds(footer);
 
-    area.removeFromBottom(4);
+    area.removeFromBottom(Theme::sectionGap);
 
-    // === SAMPLE INFO ROW ===
-    auto infoRow = area.removeFromBottom(20);
-    sampleInfoLabel.setBounds(infoRow);
-    area.removeFromBottom(4);
-
-    // === RIGHT SIDEBAR (effects + modulation, 280px) ===
-    const int sidebarWidth = 280;
+    // === RIGHT SIDEBAR (effects + modulation, 260px) ===
+    const int sidebarWidth = 260;
     bool sidebarVisible = effectsPanel.isVisible() || modulationPanel.isVisible();
 
     juce::Rectangle<int> sidebarArea;
@@ -260,43 +292,46 @@ void MainEditor::resized()
     }
 
     // === TOP SECTION: Waveform (left) + Browser (right) ===
-    auto topSection = area.removeFromTop(180);
+    auto topSection = area.removeFromTop(210);
     {
-        auto browserArea = topSection.removeFromRight(200);
-        topSection.removeFromRight(6);
+        auto browserArea = topSection.removeFromRight(220);
+        topSection.removeFromRight(Theme::sectionGap);
         sampleBrowser.setBounds(browserArea);
         waveformView.setBounds(topSection);
     }
-    area.removeFromTop(6);
+    area.removeFromTop(Theme::sectionGap);
 
     // === TRANSPORT ROW ===
-    auto transportRow = area.removeFromTop(30);
-    playButton.setBounds(transportRow.removeFromLeft(55));
-    transportRow.removeFromLeft(4);
-    stopButton.setBounds(transportRow.removeFromLeft(50));
-    transportRow.removeFromLeft(4);
-    loopButton.setBounds(transportRow.removeFromLeft(60));
-    transportRow.removeFromLeft(4);
-    granularToggle.setBounds(transportRow.removeFromLeft(85));
-    transportRow.removeFromLeft(12);
-    loadButton.setBounds(transportRow.removeFromLeft(55));
+    transportBarBounds = area.removeFromTop(36);
+    auto transportRow = transportBarBounds.reduced(10, 5);
+    auto loadZone = transportRow.removeFromRight(116);
+    loadButton.setBounds(loadZone);
+    transportRow.removeFromRight(14);
 
-    area.removeFromTop(6);
+    playButton.setBounds(transportRow.removeFromLeft(72));
+    transportRow.removeFromLeft(6);
+    stopButton.setBounds(transportRow.removeFromLeft(64));
+    transportRow.removeFromLeft(10);
+    loopButton.setBounds(transportRow.removeFromLeft(74));
+    transportRow.removeFromLeft(8);
+    granularToggle.setBounds(transportRow.removeFromLeft(102));
+
+    area.removeFromTop(Theme::sectionGap);
 
     // === CENTER: Granular controls ===
     if (granularPanel.isVisible())
     {
-        granularPanel.setBounds(area.removeFromTop(170));
-        area.removeFromTop(6);
+        granularPanel.setBounds(area.removeFromTop(160));
+        area.removeFromTop(Theme::sectionGap);
     }
 
     // === BOTTOM: Sub tuner (left) + Resample history (right) ===
     {
         auto bottomArea = area;
-        int halfWidth = bottomArea.getWidth() / 2 - 3;
+        int subWidth = static_cast<int>(bottomArea.getWidth() * 0.55f);
 
-        auto subArea = bottomArea.removeFromLeft(halfWidth);
-        bottomArea.removeFromLeft(6);
+        auto subArea = bottomArea.removeFromLeft(subWidth);
+        bottomArea.removeFromLeft(Theme::sectionGap);
         auto resampleArea = bottomArea;
 
         subPanel.setBounds(subArea);
@@ -371,7 +406,7 @@ void MainEditor::loadFile(const juce::File& file)
                 + " | " + juce::String(meta.lengthSeconds, 2) + "s"
                 + " | " + juce::String(meta.numChannels) + "ch"
                 + " | " + juce::String(static_cast<int>(meta.originalSampleRate)) + " Hz";
-            sampleInfoLabel.setText(info, juce::dontSendNotification);
+            setSampleInfoText(info);
             updateTransportButtons();
         }
 
@@ -401,15 +436,23 @@ void MainEditor::loadFactorySample(const FactorySample& sample)
     juce::String info = sample.name + " (" + sample.category + ")"
         + " | " + juce::String(lengthSec, 2) + "s"
         + " | " + juce::String(static_cast<int>(sample.sampleRate)) + " Hz";
-    sampleInfoLabel.setText(info, juce::dontSendNotification);
+    setSampleInfoText(info);
 
     updateTransportButtons();
     updateStatusLabel("Loaded factory sample: " + sample.name);
 }
 
+void MainEditor::setSampleInfoText(const juce::String& text)
+{
+    sampleInfoText = text;
+    sampleInfoLabel.setText(sampleInfoText, juce::dontSendNotification);
+}
+
 void MainEditor::updateStatusLabel(const juce::String& text)
 {
     statusLabel.setText(text, juce::dontSendNotification);
+    statusMessageDeadlineMs = juce::Time::getMillisecondCounterHiRes() + 4000.0;
+    statusLabel.setVisible(true);
 }
 
 void MainEditor::updateTransportButtons()
@@ -417,6 +460,11 @@ void MainEditor::updateTransportButtons()
     auto isPlaying = audioEngine.getTransportState() == TransportState::Playing;
     playButton.setEnabled(!isPlaying);
     stopButton.setEnabled(isPlaying);
+    playButton.setColour(juce::TextButton::buttonColourId,
+                         juce::Colour(isPlaying ? Theme::buttonPrimary : Theme::buttonSecondary));
+    playButton.setColour(juce::TextButton::textColourOffId,
+                         juce::Colour(isPlaying ? Theme::bgDarkest : Theme::textBright));
+    stopButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonSecondary));
 }
 
 void MainEditor::pushGranularParams()
@@ -494,10 +542,16 @@ void MainEditor::timerCallback()
         resamplePanel.setCaptureProgress(re.getCaptureProgress());
 
     // Update MIDI activity indicator
-    if (audioEngine.getMidiManager().consumeActivity())
-        midiActivityLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::accentGreen));
-    else
-        midiActivityLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textMuted));
+    midiIndicatorActive = audioEngine.getMidiManager().consumeActivity();
+
+    if (statusMessageDeadlineMs > 0.0
+        && juce::Time::getMillisecondCounterHiRes() > statusMessageDeadlineMs)
+    {
+        statusMessageDeadlineMs = 0.0;
+        statusLabel.setVisible(false);
+    }
+
+    repaint(titleBarBounds);
 }
 
 void MainEditor::handleResample()
@@ -620,7 +674,7 @@ void MainEditor::reloadFromHistory(const ResampleHistoryEntry* entry)
         + " | " + juce::String(entry->getLengthSeconds(), 2) + "s"
         + " | 2ch"
         + " | " + juce::String(static_cast<int>(entry->sampleRate)) + " Hz";
-    sampleInfoLabel.setText(info, juce::dontSendNotification);
+    setSampleInfoText(info);
     updateTransportButtons();
 }
 

--- a/Source/UI/MainEditor.cpp
+++ b/Source/UI/MainEditor.cpp
@@ -26,6 +26,7 @@ MainEditor::MainEditor(AudioEngine& engine, SourceSampleManager& manager)
     addAndMakeVisible(sampleBrowser);
     sampleBrowser.onLoadSample = [this](const FactorySample& sample) { loadFactorySample(sample); };
     sampleBrowser.onPreviewSample = [this](const FactorySample& sample) { loadFactorySample(sample); };
+    sampleBrowser.onImportSample = [this] { loadButton.triggerClick(); };
 
     // Transport buttons
     addAndMakeVisible(playButton);
@@ -407,6 +408,7 @@ void MainEditor::loadFile(const juce::File& file)
                 + " | " + juce::String(meta.numChannels) + "ch"
                 + " | " + juce::String(static_cast<int>(meta.originalSampleRate)) + " Hz";
             setSampleInfoText(info);
+            sampleBrowser.clearLoadedSample();
             updateTransportButtons();
         }
 
@@ -439,6 +441,7 @@ void MainEditor::loadFactorySample(const FactorySample& sample)
     setSampleInfoText(info);
 
     updateTransportButtons();
+    sampleBrowser.setLoadedSample(sample.name, sample.category);
     updateStatusLabel("Loaded factory sample: " + sample.name);
 }
 
@@ -675,6 +678,7 @@ void MainEditor::reloadFromHistory(const ResampleHistoryEntry* entry)
         + " | 2ch"
         + " | " + juce::String(static_cast<int>(entry->sampleRate)) + " Hz";
     setSampleInfoText(info);
+    sampleBrowser.clearLoadedSample();
     updateTransportButtons();
 }
 

--- a/Source/UI/MainEditor.h
+++ b/Source/UI/MainEditor.h
@@ -46,6 +46,7 @@ public:
 private:
     void loadFile(const juce::File& file);
     void loadFactorySample(const FactorySample& sample);
+    void setSampleInfoText(const juce::String& text);
     void updateStatusLabel(const juce::String& text);
     void updateTransportButtons();
 
@@ -81,7 +82,6 @@ private:
     // Info
     juce::Label rootNoteLabel;
     juce::Label sampleInfoLabel;
-    juce::Label midiActivityLabel;
 
     // === CENTER ===
     GranularPanel granularPanel;
@@ -102,6 +102,15 @@ private:
     juce::ToggleButton monoLockToggle { "Mono" };
     juce::TextButton exportButton { "Export WAV" };
     juce::Label statusLabel;
+
+    juce::String sampleInfoText;
+    double statusMessageDeadlineMs = 0.0;
+    bool midiIndicatorActive = false;
+
+    juce::Rectangle<int> titleBarBounds;
+    juce::Rectangle<int> transportBarBounds;
+    juce::Rectangle<int> footerBarBounds;
+    juce::Rectangle<int> midiIndicatorBounds;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainEditor)
 };

--- a/Source/UI/ModulationPanel.cpp
+++ b/Source/UI/ModulationPanel.cpp
@@ -2,26 +2,448 @@
 
 namespace grainhex {
 
-ModulationPanel::ModulationPanel()
+namespace {
+
+void styleLabel(juce::Label& label, juce::Justification justification)
 {
-    auto setupSlider = [this](juce::Slider& s, juce::Label& l, double min, double max, double def, double step)
+    label.setJustificationType(justification);
+    label.setFont(juce::Font(Theme::fontLabel));
+    label.setColour(juce::Label::textColourId, juce::Colour(Theme::textNormal));
+}
+
+void styleCombo(juce::ComboBox& box)
+{
+    box.setColour(juce::ComboBox::backgroundColourId, juce::Colour(Theme::bgControl));
+    box.setColour(juce::ComboBox::outlineColourId, juce::Colour(Theme::border));
+    box.setColour(juce::ComboBox::textColourId, juce::Colour(Theme::textNormal));
+}
+
+void styleRotarySlider(juce::Slider& slider, double min, double max,
+                       double def, double step, juce::Colour accent)
+{
+    slider.setRange(min, max, step);
+    slider.setValue(def, juce::dontSendNotification);
+    slider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
+    slider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 58, 16);
+    slider.setColour(juce::Slider::rotarySliderFillColourId, accent);
+}
+
+void styleHiddenSlider(juce::Slider& slider, double min, double max, double def, double step)
+{
+    slider.setRange(min, max, step);
+    slider.setValue(def, juce::dontSendNotification);
+    slider.setSliderStyle(juce::Slider::LinearHorizontal);
+    slider.setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
+    slider.setVisible(false);
+}
+
+} // namespace
+
+ModulationPanel::LFOShapePreview::LFOShapePreview()
+{
+    startTimerHz(30);
+    lastTickMs = juce::Time::getMillisecondCounterHiRes();
+}
+
+void ModulationPanel::LFOShapePreview::setState(LFOShape newShape, float newRateHz, bool isEnabled)
+{
+    shape = newShape;
+    rateHz = juce::jmax(0.01f, newRateHz);
+    enabled = isEnabled;
+    repaint();
+}
+
+float ModulationPanel::LFOShapePreview::evaluateShape(float phaseNorm) const
+{
+    switch (shape)
     {
-        addAndMakeVisible(s);
-        s.setRange(min, max, step);
-        s.setValue(def, juce::dontSendNotification);
-        s.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-        s.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 55, 16);
-        s.onValueChange = [this] { parameterChanged(); };
-        addAndMakeVisible(l);
-        l.setJustificationType(juce::Justification::centred);
-        l.setFont(juce::Font(11.0f));
-        l.setColour(juce::Label::textColourId, juce::Colours::lightgrey);
+        case LFOShape::Triangle:
+            return phaseNorm < 0.5f ? (4.0f * phaseNorm - 1.0f) : (3.0f - 4.0f * phaseNorm);
+        case LFOShape::Square:
+            return phaseNorm < 0.5f ? 1.0f : -1.0f;
+        case LFOShape::SampleAndHold:
+        {
+            const auto index = juce::jlimit(0, static_cast<int>(sampleHoldValues.size()) - 1,
+                                            static_cast<int>(phaseNorm * static_cast<float>(sampleHoldValues.size())));
+            return sampleHoldValues[static_cast<size_t>(index)];
+        }
+        case LFOShape::Sine:
+        default:
+            return std::sin(phaseNorm * juce::MathConstants<float>::twoPi);
+    }
+}
+
+void ModulationPanel::LFOShapePreview::paint(juce::Graphics& g)
+{
+    auto bounds = getLocalBounds().toFloat();
+    g.setColour(juce::Colour(Theme::bgDarkest));
+    g.fillRoundedRectangle(bounds, Theme::cornerRadius);
+    g.setColour(juce::Colour(Theme::borderSubtle));
+    g.drawRoundedRectangle(bounds.reduced(0.5f), Theme::cornerRadius, 1.0f);
+
+    auto plotBounds = bounds.reduced(8.0f, 8.0f);
+    const auto midY = plotBounds.getCentreY();
+    const auto amplitude = plotBounds.getHeight() * 0.36f;
+    const auto colour = juce::Colour(Theme::accentRed).withAlpha(enabled ? 0.95f : 0.45f);
+
+    g.setColour(juce::Colour(Theme::textMuted).withAlpha(0.22f));
+    g.drawLine(plotBounds.getX(), midY, plotBounds.getRight(), midY, 1.0f);
+
+    juce::Path outline;
+    juce::Path fill;
+    constexpr int points = 80;
+
+    for (int index = 0; index < points; ++index)
+    {
+        const auto norm = static_cast<float>(index) / static_cast<float>(points - 1);
+        const auto x = plotBounds.getX() + plotBounds.getWidth() * norm;
+        const auto y = midY - evaluateShape(norm) * amplitude;
+
+        if (index == 0)
+        {
+            outline.startNewSubPath(x, y);
+            fill.startNewSubPath(x, midY);
+            fill.lineTo(x, y);
+        }
+        else
+        {
+            outline.lineTo(x, y);
+            fill.lineTo(x, y);
+        }
+    }
+
+    fill.lineTo(plotBounds.getRight(), midY);
+    fill.closeSubPath();
+
+    g.setColour(colour.withAlpha(enabled ? 0.18f : 0.08f));
+    g.fillPath(fill);
+
+    g.setColour(colour);
+    g.strokePath(outline, juce::PathStrokeType(2.0f, juce::PathStrokeType::curved,
+                                               juce::PathStrokeType::rounded));
+
+    const auto playX = plotBounds.getX() + static_cast<float>(phase) * plotBounds.getWidth();
+    g.setColour(juce::Colour(Theme::textBright).withAlpha(enabled ? 0.8f : 0.25f));
+    g.drawLine(playX, plotBounds.getY(), playX, plotBounds.getBottom(), 1.5f);
+}
+
+void ModulationPanel::LFOShapePreview::timerCallback()
+{
+    const auto now = juce::Time::getMillisecondCounterHiRes();
+    const auto deltaSeconds = (now - lastTickMs) / 1000.0;
+    lastTickMs = now;
+
+    if (enabled && isShowing())
+    {
+        phase += deltaSeconds * static_cast<double>(rateHz);
+        phase = std::fmod(phase, 1.0);
+        if (phase < 0.0)
+            phase += 1.0;
+    }
+
+    repaint();
+}
+
+ModulationPanel::EnvelopeEditor::EnvelopeEditor(juce::Slider& attack, juce::Slider& decay,
+                                                juce::Slider& sustain, juce::Slider& release)
+    : attackSlider(attack), decaySlider(decay), sustainSlider(sustain), releaseSlider(release)
+{
+    setRepaintsOnMouseActivity(true);
+}
+
+float ModulationPanel::EnvelopeEditor::segmentWidthForTime(float seconds) const
+{
+    constexpr float minTime = 0.001f;
+    const auto norm = juce::jlimit(0.0f, 1.0f, (seconds - minTime) / (maxEnvelopeTime - minTime));
+    return minSegmentWidth + std::pow(norm, 0.35f) * extraSegmentWidth;
+}
+
+float ModulationPanel::EnvelopeEditor::timeForSegmentWidth(float width) const
+{
+    constexpr float minTime = 0.001f;
+    const auto norm = juce::jlimit(0.0f, 1.0f, (width - minSegmentWidth) / extraSegmentWidth);
+    return minTime + std::pow(norm, 1.0f / 0.35f) * (maxEnvelopeTime - minTime);
+}
+
+ModulationPanel::EnvelopeEditor::Layout ModulationPanel::EnvelopeEditor::getLayout() const
+{
+    auto plotBounds = getLocalBounds().toFloat().reduced(14.0f, 10.0f);
+    plotBounds.removeFromTop(20.0f);
+    plotBounds.removeFromBottom(14.0f);
+    plotBounds = plotBounds.reduced(2.0f, 2.0f);
+
+    auto attackWidth = segmentWidthForTime(static_cast<float>(attackSlider.getValue()));
+    auto decayWidth = segmentWidthForTime(static_cast<float>(decaySlider.getValue()));
+    auto releaseWidth = segmentWidthForTime(static_cast<float>(releaseSlider.getValue()));
+
+    const auto usedWidth = attackWidth + decayWidth + releaseWidth;
+    if (usedWidth > plotBounds.getWidth() && usedWidth > 0.0f)
+    {
+        const auto scale = plotBounds.getWidth() / usedWidth;
+        attackWidth *= scale;
+        decayWidth *= scale;
+        releaseWidth *= scale;
+    }
+
+    const auto start = juce::Point<float>(plotBounds.getX(), plotBounds.getBottom());
+    const auto peak = juce::Point<float>(start.x + attackWidth, plotBounds.getY());
+    const auto sustainY = juce::jmap(static_cast<float>(sustainSlider.getValue()), 0.0f, 1.0f,
+                                     plotBounds.getBottom(), plotBounds.getY());
+    const auto sustain = juce::Point<float>(peak.x + decayWidth, sustainY);
+    const auto end = juce::Point<float>(juce::jmin(plotBounds.getRight(), sustain.x + releaseWidth),
+                                        plotBounds.getBottom());
+
+    return { plotBounds, start, peak, sustain, end };
+}
+
+juce::String ModulationPanel::EnvelopeEditor::formatTime(float seconds) const
+{
+    if (seconds >= 1.0f)
+        return juce::String(seconds, 1) + "s";
+
+    return juce::String(static_cast<int>(std::round(seconds * 1000.0f))) + "ms";
+}
+
+ModulationPanel::EnvelopeEditor::DragNode ModulationPanel::EnvelopeEditor::hitTestNode(juce::Point<float> position) const
+{
+    const auto layout = getLayout();
+    const auto attackDistance = position.getDistanceFrom(layout.peak);
+    const auto sustainDistance = position.getDistanceFrom(layout.sustain);
+    const auto releaseDistance = position.getDistanceFrom(layout.end);
+
+    constexpr float hitRadius = 12.0f;
+    if (attackDistance <= hitRadius)
+        return DragNode::attackPeak;
+    if (sustainDistance <= hitRadius)
+        return DragNode::sustainPoint;
+    if (releaseDistance <= hitRadius)
+        return DragNode::releaseEnd;
+    return DragNode::none;
+}
+
+void ModulationPanel::EnvelopeEditor::setHoveredNode(DragNode node)
+{
+    if (hoveredNode == node)
+        return;
+
+    hoveredNode = node;
+    auto cursorNode = activeNode != DragNode::none ? activeNode : hoveredNode;
+    switch (cursorNode)
+    {
+        case DragNode::attackPeak:
+        case DragNode::releaseEnd:
+            setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
+            break;
+        case DragNode::sustainPoint:
+            setMouseCursor(juce::MouseCursor::DraggingHandCursor);
+            break;
+        case DragNode::none:
+        default:
+            setMouseCursor(juce::MouseCursor::NormalCursor);
+            break;
+    }
+    repaint();
+}
+
+void ModulationPanel::EnvelopeEditor::paint(juce::Graphics& g)
+{
+    const auto bounds = getLocalBounds().toFloat();
+    const auto layout = getLayout();
+    const auto attackColour = juce::Colour(Theme::accentRed);
+    const auto decayColour = juce::Colour(Theme::accentOrange);
+    const auto releaseColour = juce::Colour(Theme::accentCyan);
+    const auto labelBounds = getLocalBounds().reduced(12, 4);
+
+    g.setColour(juce::Colour(Theme::bgDarkest));
+    g.fillRoundedRectangle(bounds, Theme::cornerRadius);
+    g.setColour(juce::Colour(Theme::borderSubtle));
+    g.drawRoundedRectangle(bounds.reduced(0.5f), Theme::cornerRadius, 1.0f);
+
+    g.setColour(juce::Colour(Theme::textMuted).withAlpha(0.25f));
+    g.drawLine(layout.plotBounds.getX(), layout.plotBounds.getBottom(),
+               layout.plotBounds.getRight(), layout.plotBounds.getBottom(), 1.0f);
+
+    g.drawLine(layout.peak.x, layout.plotBounds.getY(), layout.peak.x, layout.plotBounds.getBottom(), 1.0f);
+    g.drawLine(layout.sustain.x, layout.plotBounds.getY(), layout.sustain.x, layout.plotBounds.getBottom(), 1.0f);
+    g.drawLine(layout.end.x, layout.plotBounds.getY(), layout.end.x, layout.plotBounds.getBottom(), 1.0f);
+
+    juce::Path attackPath;
+    attackPath.startNewSubPath(layout.start);
+    attackPath.quadraticTo(layout.start.x + (layout.peak.x - layout.start.x) * 0.58f,
+                           layout.start.y - layout.plotBounds.getHeight() * 0.18f,
+                           layout.peak.x, layout.peak.y);
+
+    juce::Path decayPath;
+    decayPath.startNewSubPath(layout.peak);
+    decayPath.quadraticTo(layout.peak.x + (layout.sustain.x - layout.peak.x) * 0.42f,
+                          layout.sustain.y - layout.plotBounds.getHeight() * 0.24f,
+                          layout.sustain.x, layout.sustain.y);
+
+    juce::Path releasePath;
+    releasePath.startNewSubPath(layout.sustain);
+    releasePath.quadraticTo(layout.sustain.x + (layout.end.x - layout.sustain.x) * 0.35f,
+                            layout.sustain.y + layout.plotBounds.getHeight() * 0.12f,
+                            layout.end.x, layout.end.y);
+
+    auto fillSegment = [&](const juce::Path& segment, juce::Colour colour)
+    {
+        juce::Path filled = segment;
+        const auto endPoint = segment.getCurrentPosition();
+        filled.lineTo(endPoint.x, layout.plotBounds.getBottom());
+        filled.lineTo(segment.getBounds().getX(), layout.plotBounds.getBottom());
+        filled.closeSubPath();
+        g.setColour(colour.withAlpha(0.15f));
+        g.fillPath(filled);
+        g.setColour(colour);
+        g.strokePath(segment, juce::PathStrokeType(2.2f, juce::PathStrokeType::curved,
+                                                   juce::PathStrokeType::rounded));
     };
 
-    // -- LFO section --
+    fillSegment(attackPath, attackColour);
+    fillSegment(decayPath, decayColour);
+    g.setColour(decayColour.withAlpha(0.65f));
+    const float dashes[] { 4.0f, 4.0f };
+    g.drawDashedLine({ layout.sustain.x, layout.sustain.y, layout.plotBounds.getRight(), layout.sustain.y },
+                     dashes, 2, 1.0f);
+    fillSegment(releasePath, releaseColour);
+
+    g.setFont(juce::Font(Theme::fontMetadata).boldened());
+    g.setColour(attackColour);
+    g.drawText("ATTACK " + formatTime(static_cast<float>(attackSlider.getValue())),
+               juce::Rectangle<int>(juce::roundToInt(layout.start.x), labelBounds.getY(), 88, 14),
+               juce::Justification::centredLeft, false);
+    g.setColour(decayColour);
+    g.drawText("DECAY " + formatTime(static_cast<float>(decaySlider.getValue())),
+               juce::Rectangle<int>(juce::roundToInt(layout.peak.x) - 28, labelBounds.getY(), 104, 14),
+               juce::Justification::centredLeft, false);
+    g.setColour(releaseColour);
+    g.drawText("RELEASE " + formatTime(static_cast<float>(releaseSlider.getValue())),
+               juce::Rectangle<int>(juce::roundToInt(layout.sustain.x) - 18, labelBounds.getY(), 128, 14),
+               juce::Justification::centredLeft, false);
+
+    g.setColour(juce::Colour(Theme::textDim));
+    g.setFont(juce::Font(Theme::fontMetadata));
+    g.drawText("SUSTAIN " + juce::String(static_cast<int>(std::round(sustainSlider.getValue() * 100.0))) + "%",
+               getLocalBounds().reduced(12, 8).removeFromBottom(14),
+               juce::Justification::centredRight, false);
+
+    auto drawNode = [&](juce::Point<float> point, juce::Colour outline, DragNode node, bool draggable)
+    {
+        const bool highlighted = node == activeNode || node == hoveredNode;
+        const float radius = draggable ? (highlighted ? 8.0f : 6.0f) : 4.0f;
+        g.setColour(juce::Colour(Theme::textBright));
+        g.fillEllipse(point.x - radius, point.y - radius, radius * 2.0f, radius * 2.0f);
+        g.setColour(outline);
+        g.drawEllipse(point.x - radius, point.y - radius, radius * 2.0f, radius * 2.0f, highlighted ? 2.0f : 1.4f);
+    };
+
+    drawNode(layout.start, juce::Colour(Theme::textMuted), DragNode::none, false);
+    drawNode(layout.peak, attackColour, DragNode::attackPeak, true);
+    drawNode(layout.sustain, decayColour, DragNode::sustainPoint, true);
+    drawNode(layout.end, releaseColour, DragNode::releaseEnd, true);
+}
+
+void ModulationPanel::EnvelopeEditor::mouseMove(const juce::MouseEvent& event)
+{
+    setHoveredNode(hitTestNode(event.position));
+}
+
+void ModulationPanel::EnvelopeEditor::mouseExit(const juce::MouseEvent& event)
+{
+    juce::ignoreUnused(event);
+    if (activeNode == DragNode::none)
+        setHoveredNode(DragNode::none);
+}
+
+void ModulationPanel::EnvelopeEditor::mouseDown(const juce::MouseEvent& event)
+{
+    activeNode = hitTestNode(event.position);
+    switch (activeNode)
+    {
+        case DragNode::attackPeak:
+        case DragNode::releaseEnd:
+            setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
+            break;
+        case DragNode::sustainPoint:
+            setMouseCursor(juce::MouseCursor::DraggingHandCursor);
+            break;
+        case DragNode::none:
+        default:
+            setMouseCursor(juce::MouseCursor::NormalCursor);
+            break;
+    }
+    repaint();
+}
+
+void ModulationPanel::EnvelopeEditor::mouseDrag(const juce::MouseEvent& event)
+{
+    if (activeNode == DragNode::none)
+        return;
+
+    const auto layout = getLayout();
+    const auto availableWidth = layout.plotBounds.getWidth();
+    const auto attackWidth = layout.peak.x - layout.start.x;
+    const auto decayWidth = layout.sustain.x - layout.peak.x;
+
+    switch (activeNode)
+    {
+        case DragNode::attackPeak:
+        {
+            const auto width = juce::jlimit(minSegmentWidth, availableWidth - minSegmentWidth * 2.0f,
+                                            event.position.x - layout.start.x);
+            attackSlider.setValue(timeForSegmentWidth(width), juce::sendNotificationSync);
+            break;
+        }
+
+        case DragNode::sustainPoint:
+        {
+            const auto width = juce::jlimit(minSegmentWidth, availableWidth - attackWidth - minSegmentWidth,
+                                            event.position.x - layout.peak.x);
+            decaySlider.setValue(timeForSegmentWidth(width), juce::sendNotificationSync);
+
+            const auto sustain = juce::jlimit(0.0f, 1.0f,
+                                              (layout.plotBounds.getBottom() - event.position.y)
+                                                  / juce::jmax(1.0f, layout.plotBounds.getHeight()));
+            sustainSlider.setValue(sustain, juce::sendNotificationSync);
+            break;
+        }
+
+        case DragNode::releaseEnd:
+        {
+            const auto width = juce::jlimit(minSegmentWidth, availableWidth - attackWidth - decayWidth,
+                                            event.position.x - layout.sustain.x);
+            releaseSlider.setValue(timeForSegmentWidth(width), juce::sendNotificationSync);
+            break;
+        }
+
+        case DragNode::none:
+        default:
+            break;
+    }
+}
+
+void ModulationPanel::EnvelopeEditor::mouseUp(const juce::MouseEvent& event)
+{
+    juce::ignoreUnused(event);
+    activeNode = DragNode::none;
+    setHoveredNode(hitTestNode(getMouseXYRelative().toFloat()));
+}
+
+ModulationPanel::ModulationPanel()
+{
     addAndMakeVisible(lfoToggle);
     lfoToggle.setToggleState(false, juce::dontSendNotification);
-    lfoToggle.onClick = [this] { parameterChanged(); };
+    lfoToggle.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentRed));
+    lfoToggle.onClick = [this]
+    {
+        updateSectionVisibility();
+        updatePreviewState();
+        resized();
+        repaint();
+        parameterChanged();
+    };
+
+    addAndMakeVisible(lfoPreview);
 
     addAndMakeVisible(lfoShapeBox);
     lfoShapeBox.addItem("Sine", 1);
@@ -29,29 +451,105 @@ ModulationPanel::ModulationPanel()
     lfoShapeBox.addItem("Square", 3);
     lfoShapeBox.addItem("S&H", 4);
     lfoShapeBox.setSelectedId(1, juce::dontSendNotification);
-    lfoShapeBox.onChange = [this] { parameterChanged(); };
-    addAndMakeVisible(lfoShapeLabel);
+    lfoShapeBox.onChange = [this]
+    {
+        updatePreviewState();
+        parameterChanged();
+    };
+    styleCombo(lfoShapeBox);
 
-    setupSlider(lfoRateSlider, lfoRateLabel, 0.01, 30.0, 1.0, 0.01);
+    addAndMakeVisible(lfoSyncBox);
+    lfoSyncBox.addItem("Free", 1);
+    lfoSyncBox.addItem("1/1", 2);
+    lfoSyncBox.addItem("1/2", 3);
+    lfoSyncBox.addItem("1/4", 4);
+    lfoSyncBox.addItem("1/8", 5);
+    lfoSyncBox.addItem("1/16", 6);
+    lfoSyncBox.addItem("1/4T", 7);
+    lfoSyncBox.addItem("1/8T", 8);
+    lfoSyncBox.addItem("1/4.", 9);
+    lfoSyncBox.addItem("1/8.", 10);
+    lfoSyncBox.setSelectedId(1, juce::dontSendNotification);
+    lfoSyncBox.onChange = [this]
+    {
+        updatePreviewState();
+        parameterChanged();
+    };
+    styleCombo(lfoSyncBox);
+
+    styleRotarySlider(lfoRateSlider, 0.01, 30.0, 1.0, 0.01, juce::Colour(Theme::accentRed));
     lfoRateSlider.setSkewFactorFromMidPoint(3.0);
+    lfoRateSlider.setTextValueSuffix(" Hz");
+    lfoRateSlider.onValueChange = [this]
+    {
+        updatePreviewState();
+        parameterChanged();
+    };
+    addAndMakeVisible(lfoRateSlider);
 
-    setupSlider(lfoDepthSlider, lfoDepthLabel, 0.0, 1.0, 0.5, 0.01);
+    styleRotarySlider(lfoDepthSlider, 0.0, 1.0, 0.5, 0.01, juce::Colour(Theme::accentRed));
+    lfoDepthSlider.onValueChange = [this] { parameterChanged(); };
+    addAndMakeVisible(lfoDepthSlider);
 
-    // -- ADSR section --
+    for (auto* label : { &lfoShapeLabel, &lfoRateLabel, &lfoDepthLabel, &lfoSyncLabel })
+    {
+        addAndMakeVisible(*label);
+    }
+    styleLabel(lfoShapeLabel, juce::Justification::centredLeft);
+    styleLabel(lfoSyncLabel, juce::Justification::centredLeft);
+    styleLabel(lfoRateLabel, juce::Justification::centred);
+    styleLabel(lfoDepthLabel, juce::Justification::centred);
+
     addAndMakeVisible(envToggle);
     envToggle.setToggleState(false, juce::dontSendNotification);
-    envToggle.onClick = [this] { parameterChanged(); };
+    envToggle.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentRed));
+    envToggle.onClick = [this]
+    {
+        updateSectionVisibility();
+        resized();
+        repaint();
+        parameterChanged();
+    };
 
-    setupSlider(attackSlider, attackLabel, 0.001, 10.0, 0.01, 0.001);
+    styleHiddenSlider(attackSlider, 0.001, 10.0, 0.01, 0.001);
     attackSlider.setSkewFactorFromMidPoint(0.5);
+    attackSlider.onValueChange = [this]
+    {
+        envelopeEditor.repaint();
+        parameterChanged();
+    };
+    addChildComponent(attackSlider);
 
-    setupSlider(decaySlider, decayLabel, 0.001, 10.0, 0.1, 0.001);
+    styleHiddenSlider(decaySlider, 0.001, 10.0, 0.1, 0.001);
     decaySlider.setSkewFactorFromMidPoint(0.5);
+    decaySlider.onValueChange = [this]
+    {
+        envelopeEditor.repaint();
+        parameterChanged();
+    };
+    addChildComponent(decaySlider);
 
-    setupSlider(sustainSlider, sustainLabel, 0.0, 1.0, 0.7, 0.01);
+    styleHiddenSlider(sustainSlider, 0.0, 1.0, 0.7, 0.01);
+    sustainSlider.onValueChange = [this]
+    {
+        envelopeEditor.repaint();
+        parameterChanged();
+    };
+    addChildComponent(sustainSlider);
 
-    setupSlider(releaseSlider, releaseLabel, 0.001, 10.0, 0.3, 0.001);
+    styleHiddenSlider(releaseSlider, 0.001, 10.0, 0.3, 0.001);
     releaseSlider.setSkewFactorFromMidPoint(0.5);
+    releaseSlider.onValueChange = [this]
+    {
+        envelopeEditor.repaint();
+        parameterChanged();
+    };
+    addChildComponent(releaseSlider);
+
+    addAndMakeVisible(envelopeEditor);
+
+    updateSectionVisibility();
+    updatePreviewState();
 }
 
 void ModulationPanel::paint(juce::Graphics& g)
@@ -64,76 +562,245 @@ void ModulationPanel::paint(juce::Graphics& g)
 
     g.setColour(juce::Colour(Theme::accentRed));
     g.setFont(juce::Font(Theme::fontSectionHead).boldened());
-    g.drawText("MODULATION", 10, 4, 120, 20, juce::Justification::centredLeft);
+    g.drawText("MODULATION", 12, 6, 120, 18, juce::Justification::centredLeft);
 
-    // Separator
-    int midY = getHeight() / 2 + 8;
-    g.setColour(juce::Colour(Theme::border));
-    g.drawHorizontalLine(midY, 8.0f, static_cast<float>(getWidth() - 8));
+    auto drawSection = [&](juce::Rectangle<int> headerBounds, juce::Rectangle<int> bodyBounds,
+                           const juce::String& title, bool enabled, bool expanded)
+    {
+        g.setColour(enabled ? juce::Colour(Theme::bgPanelHover) : juce::Colour(Theme::bgControl));
+        g.fillRoundedRectangle(headerBounds.toFloat(), Theme::cornerRadius);
+        g.setColour(enabled ? juce::Colour(Theme::borderActive) : juce::Colour(Theme::border));
+        g.drawRoundedRectangle(headerBounds.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+
+        juce::Path chevron;
+        const auto cx = static_cast<float>(headerBounds.getRight() - 14);
+        const auto cy = static_cast<float>(headerBounds.getCentreY());
+        if (expanded && enabled)
+        {
+            chevron.startNewSubPath(cx - 4.0f, cy - 2.0f);
+            chevron.lineTo(cx, cy + 2.5f);
+            chevron.lineTo(cx + 4.0f, cy - 2.0f);
+        }
+        else
+        {
+            chevron.startNewSubPath(cx - 2.0f, cy - 4.0f);
+            chevron.lineTo(cx + 2.5f, cy);
+            chevron.lineTo(cx - 2.0f, cy + 4.0f);
+        }
+
+        g.setColour(juce::Colour(Theme::textBright));
+        g.setFont(juce::Font(Theme::fontValue).boldened());
+        g.drawText(title, headerBounds.withTrimmedLeft(36).withTrimmedRight(26),
+                   juce::Justification::centredLeft, false);
+        g.strokePath(chevron, juce::PathStrokeType(1.5f, juce::PathStrokeType::curved,
+                                                   juce::PathStrokeType::rounded));
+
+        if (enabled && expanded && !bodyBounds.isEmpty())
+        {
+            g.setColour(juce::Colour(Theme::bgElevated));
+            g.fillRoundedRectangle(bodyBounds.toFloat(), Theme::cornerRadius);
+            g.setColour(juce::Colour(Theme::borderSubtle));
+            g.drawRoundedRectangle(bodyBounds.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+        }
+    };
+
+    drawSection(lfoHeaderBounds, lfoBodyBounds, "LFO", lfoToggle.getToggleState(), lfoExpanded);
+    drawSection(envHeaderBounds, envBodyBounds, "Envelope", envToggle.getToggleState(), envExpanded);
 }
 
 void ModulationPanel::resized()
 {
-    auto area = getLocalBounds().reduced(8);
-    area.removeFromTop(22); // Title
+    auto area = getLocalBounds().reduced(Theme::panelPadding);
+    area.removeFromTop(24);
 
-    int halfHeight = area.getHeight() / 2 - 2;
+    constexpr int headerHeight = 24;
+    const bool showLfoBody = lfoToggle.getToggleState() && lfoExpanded;
+    const bool showEnvBody = envToggle.getToggleState() && envExpanded;
+    const int availableBodyHeight = juce::jmax(0, area.getHeight() - headerHeight * 2 - Theme::sectionGap);
 
-    // LFO section (top)
-    auto lfoArea = area.removeFromTop(halfHeight).reduced(2);
+    int lfoBodyHeight = 0;
+    int envBodyHeight = 0;
+    if (showLfoBody && showEnvBody)
     {
-        auto topRow = lfoArea.removeFromTop(24);
-        lfoToggle.setBounds(topRow.removeFromLeft(50));
-        lfoShapeLabel.setBounds(topRow.removeFromLeft(35));
-        lfoShapeBox.setBounds(topRow);
-
-        lfoArea.removeFromTop(4);
-        auto knobRow = lfoArea;
-        int knobW = knobRow.getWidth() / 2;
-
-        auto rateArea = knobRow.removeFromLeft(knobW);
-        lfoRateLabel.setBounds(rateArea.removeFromTop(16));
-        lfoRateSlider.setBounds(rateArea);
-
-        auto depthArea = knobRow;
-        lfoDepthLabel.setBounds(depthArea.removeFromTop(16));
-        lfoDepthSlider.setBounds(depthArea);
+        lfoBodyHeight = juce::jlimit(114, 138, availableBodyHeight / 2);
+        envBodyHeight = juce::jmax(96, availableBodyHeight - lfoBodyHeight);
+    }
+    else if (showLfoBody)
+    {
+        lfoBodyHeight = availableBodyHeight;
+    }
+    else if (showEnvBody)
+    {
+        envBodyHeight = availableBodyHeight;
     }
 
-    area.removeFromTop(4);
-
-    // ADSR section (bottom)
-    auto envArea = area.reduced(2);
+    lfoHeaderBounds = area.removeFromTop(headerHeight);
+    if (showLfoBody)
     {
-        auto topRow = envArea.removeFromTop(24);
-        envToggle.setBounds(topRow.removeFromLeft(90));
-
-        envArea.removeFromTop(4);
-        auto knobRow = envArea;
-        int knobW = knobRow.getWidth() / 4;
-
-        auto aArea = knobRow.removeFromLeft(knobW);
-        attackLabel.setBounds(aArea.removeFromTop(16));
-        attackSlider.setBounds(aArea);
-
-        auto dArea = knobRow.removeFromLeft(knobW);
-        decayLabel.setBounds(dArea.removeFromTop(16));
-        decaySlider.setBounds(dArea);
-
-        auto sArea = knobRow.removeFromLeft(knobW);
-        sustainLabel.setBounds(sArea.removeFromTop(16));
-        sustainSlider.setBounds(sArea);
-
-        auto rArea = knobRow;
-        releaseLabel.setBounds(rArea.removeFromTop(16));
-        releaseSlider.setBounds(rArea);
+        area.removeFromTop(4);
+        lfoBodyBounds = area.removeFromTop(lfoBodyHeight);
+        area.removeFromTop(Theme::sectionGap);
     }
+    else
+    {
+        lfoBodyBounds = {};
+        area.removeFromTop(Theme::sectionGap);
+    }
+
+    envHeaderBounds = area.removeFromTop(headerHeight);
+    if (showEnvBody)
+    {
+        area.removeFromTop(4);
+        envBodyBounds = area.removeFromTop(envBodyHeight);
+    }
+    else
+    {
+        envBodyBounds = {};
+    }
+
+    lfoToggle.setBounds(lfoHeaderBounds.withTrimmedLeft(8).withWidth(28));
+    envToggle.setBounds(envHeaderBounds.withTrimmedLeft(8).withWidth(28));
+
+    auto clearHidden = [](juce::Component& component)
+    {
+        component.setBounds({});
+    };
+
+    if (showLfoBody)
+    {
+        auto body = lfoBodyBounds.reduced(10, 10);
+        lfoPreview.setBounds(body.removeFromTop(62));
+        body.removeFromTop(8);
+
+        auto leftColumn = body.removeFromLeft(88);
+        body.removeFromLeft(Theme::controlGap);
+        auto rateArea = body.removeFromLeft((body.getWidth() - Theme::controlGap) / 2);
+        body.removeFromLeft(Theme::controlGap);
+        auto depthArea = body;
+
+        constexpr int labelHeight = 14;
+        constexpr int comboHeight = 24;
+        const int knobHeight = Theme::knobSize + 18;
+
+        lfoShapeLabel.setBounds(leftColumn.removeFromTop(labelHeight));
+        lfoShapeBox.setBounds(leftColumn.removeFromTop(comboHeight));
+        leftColumn.removeFromTop(6);
+        lfoSyncLabel.setBounds(leftColumn.removeFromTop(labelHeight));
+        lfoSyncBox.setBounds(leftColumn.removeFromTop(comboHeight));
+
+        lfoRateLabel.setBounds(rateArea.removeFromTop(labelHeight));
+        lfoRateSlider.setBounds(rateArea.removeFromTop(knobHeight));
+
+        lfoDepthLabel.setBounds(depthArea.removeFromTop(labelHeight));
+        lfoDepthSlider.setBounds(depthArea.removeFromTop(knobHeight));
+    }
+    else
+    {
+        clearHidden(lfoPreview);
+        clearHidden(lfoShapeLabel);
+        clearHidden(lfoShapeBox);
+        clearHidden(lfoSyncLabel);
+        clearHidden(lfoSyncBox);
+        clearHidden(lfoRateLabel);
+        clearHidden(lfoRateSlider);
+        clearHidden(lfoDepthLabel);
+        clearHidden(lfoDepthSlider);
+    }
+
+    if (showEnvBody)
+    {
+        envelopeEditor.setBounds(envBodyBounds.reduced(10, 10));
+    }
+    else
+    {
+        clearHidden(envelopeEditor);
+    }
+}
+
+void ModulationPanel::mouseUp(const juce::MouseEvent& event)
+{
+    if (lfoHeaderBounds.contains(event.getPosition()) && !lfoToggle.getBounds().contains(event.getPosition()))
+    {
+        lfoExpanded = !lfoExpanded;
+        updateSectionVisibility();
+        resized();
+        repaint();
+        return;
+    }
+
+    if (envHeaderBounds.contains(event.getPosition()) && !envToggle.getBounds().contains(event.getPosition()))
+    {
+        envExpanded = !envExpanded;
+        updateSectionVisibility();
+        resized();
+        repaint();
+    }
+}
+
+void ModulationPanel::mouseMove(const juce::MouseEvent& event)
+{
+    if (lfoHeaderBounds.contains(event.getPosition()) || envHeaderBounds.contains(event.getPosition()))
+        setMouseCursor(juce::MouseCursor::PointingHandCursor);
+    else
+        setMouseCursor(juce::MouseCursor::NormalCursor);
 }
 
 void ModulationPanel::parameterChanged()
 {
     if (onParameterChanged)
         onParameterChanged();
+}
+
+void ModulationPanel::updateSectionVisibility()
+{
+    const bool showLfoBody = lfoToggle.getToggleState() && lfoExpanded;
+    const bool showEnvBody = envToggle.getToggleState() && envExpanded;
+
+    for (auto* component : { static_cast<juce::Component*>(&lfoPreview),
+                             static_cast<juce::Component*>(&lfoShapeLabel),
+                             static_cast<juce::Component*>(&lfoShapeBox),
+                             static_cast<juce::Component*>(&lfoSyncLabel),
+                             static_cast<juce::Component*>(&lfoSyncBox),
+                             static_cast<juce::Component*>(&lfoRateLabel),
+                             static_cast<juce::Component*>(&lfoRateSlider),
+                             static_cast<juce::Component*>(&lfoDepthLabel),
+                             static_cast<juce::Component*>(&lfoDepthSlider) })
+    {
+        component->setVisible(showLfoBody);
+    }
+
+    envelopeEditor.setVisible(showEnvBody);
+}
+
+void ModulationPanel::updatePreviewState()
+{
+    const auto syncDivision = getLFOSyncDivision();
+    const bool freeRunning = syncDivision < 0.0f;
+    const auto effectiveRate = freeRunning ? getLFORate()
+                                           : bpm / (60.0f * juce::jmax(0.125f, syncDivision));
+
+    lfoRateSlider.setEnabled(freeRunning);
+    lfoRateSlider.setAlpha(freeRunning ? 1.0f : 0.45f);
+    lfoRateLabel.setAlpha(freeRunning ? 1.0f : 0.55f);
+    lfoPreview.setState(getLFOShape(), effectiveRate, lfoToggle.getToggleState());
+}
+
+float ModulationPanel::syncIdToDivision(int selectedId)
+{
+    switch (selectedId)
+    {
+        case 2:  return 4.0f;        // 1/1
+        case 3:  return 2.0f;        // 1/2
+        case 4:  return 1.0f;        // 1/4
+        case 5:  return 0.5f;        // 1/8
+        case 6:  return 0.25f;       // 1/16
+        case 7:  return 2.0f / 3.0f; // 1/4T
+        case 8:  return 1.0f / 3.0f; // 1/8T
+        case 9:  return 1.5f;        // 1/4.
+        case 10: return 0.75f;       // 1/8.
+        case 1:
+        default: return -1.0f;
+    }
 }
 
 bool ModulationPanel::getLFOEnabled() const { return lfoToggle.getToggleState(); }
@@ -151,6 +818,13 @@ LFOShape ModulationPanel::getLFOShape() const
 
 float ModulationPanel::getLFORate() const { return static_cast<float>(lfoRateSlider.getValue()); }
 float ModulationPanel::getLFODepth() const { return static_cast<float>(lfoDepthSlider.getValue()); }
+float ModulationPanel::getLFOSyncDivision() const { return syncIdToDivision(lfoSyncBox.getSelectedId()); }
+
+void ModulationPanel::setBPM(float newBpm)
+{
+    bpm = juce::jlimit(20.0f, 300.0f, newBpm);
+    updatePreviewState();
+}
 
 bool ModulationPanel::getEnvelopeEnabled() const { return envToggle.getToggleState(); }
 float ModulationPanel::getAttack() const { return static_cast<float>(attackSlider.getValue()); }

--- a/Source/UI/ModulationPanel.h
+++ b/Source/UI/ModulationPanel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "Modulation/LFO.h"
 #include "Modulation/ADSREnvelope.h"
@@ -10,8 +11,7 @@ namespace grainhex {
 
 /**
  * UI panel for LFO and ADSR envelope controls.
- * LFO: enable, shape, rate, depth.
- * ADSR: enable, attack, decay, sustain, release.
+ * Redesigned as collapsible sections with visual editors.
  */
 class ModulationPanel : public juce::Component
 {
@@ -21,12 +21,17 @@ public:
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+    void mouseUp(const juce::MouseEvent& event) override;
+    void mouseMove(const juce::MouseEvent& event) override;
 
     // LFO accessors
     bool getLFOEnabled() const;
     LFOShape getLFOShape() const;
     float getLFORate() const;
     float getLFODepth() const;
+    float getLFOSyncDivision() const;
+    void setBPM(float newBpm);
+    float getBPM() const { return bpm; }
 
     // ADSR accessors
     bool getEnvelopeEnabled() const;
@@ -35,38 +40,118 @@ public:
     float getSustain() const;
     float getRelease() const;
 
-    // Callback
     std::function<void()> onParameterChanged;
 
 private:
+    class LFOShapePreview : public juce::Component,
+                            private juce::Timer
+    {
+    public:
+        LFOShapePreview();
+
+        void paint(juce::Graphics& g) override;
+        void setState(LFOShape newShape, float newRateHz, bool isEnabled);
+
+    private:
+        float evaluateShape(float phaseNorm) const;
+        void timerCallback() override;
+
+        LFOShape shape = LFOShape::Sine;
+        float rateHz = 1.0f;
+        double phase = 0.0;
+        double lastTickMs = 0.0;
+        bool enabled = false;
+        std::array<float, 8> sampleHoldValues { -0.82f, 0.31f, 0.74f, -0.18f,
+                                                0.56f, -0.63f, 0.14f, 0.9f };
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LFOShapePreview)
+    };
+
+    class EnvelopeEditor : public juce::Component
+    {
+    public:
+        EnvelopeEditor(juce::Slider& attack, juce::Slider& decay,
+                       juce::Slider& sustain, juce::Slider& release);
+
+        void paint(juce::Graphics& g) override;
+        void mouseMove(const juce::MouseEvent& event) override;
+        void mouseExit(const juce::MouseEvent& event) override;
+        void mouseDown(const juce::MouseEvent& event) override;
+        void mouseDrag(const juce::MouseEvent& event) override;
+        void mouseUp(const juce::MouseEvent& event) override;
+
+    private:
+        enum class DragNode
+        {
+            none,
+            attackPeak,
+            sustainPoint,
+            releaseEnd
+        };
+
+        struct Layout
+        {
+            juce::Rectangle<float> plotBounds;
+            juce::Point<float> start;
+            juce::Point<float> peak;
+            juce::Point<float> sustain;
+            juce::Point<float> end;
+        };
+
+        Layout getLayout() const;
+        float segmentWidthForTime(float seconds) const;
+        float timeForSegmentWidth(float width) const;
+        DragNode hitTestNode(juce::Point<float> position) const;
+        juce::String formatTime(float seconds) const;
+        void setHoveredNode(DragNode node);
+
+        juce::Slider& attackSlider;
+        juce::Slider& decaySlider;
+        juce::Slider& sustainSlider;
+        juce::Slider& releaseSlider;
+
+        DragNode hoveredNode = DragNode::none;
+        DragNode activeNode = DragNode::none;
+
+        static constexpr float minSegmentWidth = 24.0f;
+        static constexpr float extraSegmentWidth = 48.0f;
+        static constexpr float maxEnvelopeTime = 10.0f;
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EnvelopeEditor)
+    };
+
     void parameterChanged();
+    void updateSectionVisibility();
+    void updatePreviewState();
+    static float syncIdToDivision(int selectedId);
 
     // LFO controls
     juce::ToggleButton lfoToggle { "LFO" };
-
     juce::ComboBox lfoShapeBox;
     juce::Label lfoShapeLabel { {}, "Shape" };
-
     juce::Slider lfoRateSlider;
     juce::Label lfoRateLabel { {}, "Rate" };
-
     juce::Slider lfoDepthSlider;
     juce::Label lfoDepthLabel { {}, "Depth" };
+    juce::ComboBox lfoSyncBox;
+    juce::Label lfoSyncLabel { {}, "Sync" };
+    LFOShapePreview lfoPreview;
 
     // ADSR controls
     juce::ToggleButton envToggle { "Envelope" };
-
     juce::Slider attackSlider;
-    juce::Label attackLabel { {}, "A" };
-
     juce::Slider decaySlider;
-    juce::Label decayLabel { {}, "D" };
-
     juce::Slider sustainSlider;
-    juce::Label sustainLabel { {}, "S" };
-
     juce::Slider releaseSlider;
-    juce::Label releaseLabel { {}, "R" };
+    EnvelopeEditor envelopeEditor { attackSlider, decaySlider, sustainSlider, releaseSlider };
+
+    bool lfoExpanded = true;
+    bool envExpanded = true;
+    float bpm = 120.0f;
+    juce::Rectangle<int> lfoHeaderBounds;
+    juce::Rectangle<int> lfoBodyBounds;
+    juce::Rectangle<int> envHeaderBounds;
+    juce::Rectangle<int> envBodyBounds;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationPanel)
 };

--- a/Source/UI/ResamplePanel.cpp
+++ b/Source/UI/ResamplePanel.cpp
@@ -6,70 +6,82 @@ namespace grainhex {
 
 ResamplePanel::HistoryThumbnail::HistoryThumbnail()
 {
+    setRepaintsOnMouseActivity(true);
+    setMouseCursor(juce::MouseCursor::PointingHandCursor);
 }
 
 void ResamplePanel::HistoryThumbnail::paint(juce::Graphics& g)
 {
     auto bounds = getLocalBounds().toFloat();
+    auto bgColour = current ? juce::Colour(Theme::bgElevated) : juce::Colour(Theme::bgControl);
+    if (hovered)
+        bgColour = bgColour.brighter(0.08f);
 
-    // Background
-    auto bgColour = current ? juce::Colour(0xff1a3a2a) : juce::Colour(Theme::bgControl);
     g.setColour(bgColour);
-    g.fillRoundedRectangle(bounds, 4.0f);
+    g.fillRoundedRectangle(bounds, Theme::cornerRadius);
 
-    // Border
-    auto borderColour = current ? juce::Colour(Theme::accentGreen) : juce::Colour(Theme::border);
+    auto borderColour = current ? juce::Colour(Theme::accentGreen)
+                                : hovered ? juce::Colour(Theme::borderActive)
+                                          : juce::Colour(Theme::border);
     g.setColour(borderColour);
-    g.drawRoundedRectangle(bounds.reduced(0.5f), 4.0f, current ? 2.0f : 1.0f);
+    g.drawRoundedRectangle(bounds.reduced(0.5f), Theme::cornerRadius, current ? 2.0f : 1.0f);
 
     if (historyEntry == nullptr)
         return;
 
-    // Draw waveform preview
-    auto waveArea = bounds.reduced(4.0f, 12.0f);
-    float centreY = waveArea.getCentreY();
+    auto waveArea = bounds.reduced(8.0f, 14.0f);
+    waveArea.removeFromBottom(24.0f);
+    const auto centreY = waveArea.getCentreY();
 
-    g.setColour(current ? juce::Colour(Theme::accentGreen).withAlpha(0.8f) : juce::Colour(0xff6666aa));
+    g.setColour(current ? juce::Colour(Theme::accentGreen).withAlpha(0.9f)
+                        : juce::Colour(Theme::textDim).withAlpha(0.8f));
 
-    const int numPoints = static_cast<int>(historyEntry->previewMin.size());
+    const auto numPoints = static_cast<int>(historyEntry->previewMin.size());
     if (numPoints > 0)
     {
-        float xScale = waveArea.getWidth() / static_cast<float>(numPoints);
-        float yScale = waveArea.getHeight() * 0.5f;
+        const auto xScale = waveArea.getWidth() / static_cast<float>(numPoints);
+        const auto yScale = waveArea.getHeight() * 0.5f;
 
-        for (int i = 0; i < numPoints; ++i)
+        for (int point = 0; point < numPoints; ++point)
         {
-            float x = waveArea.getX() + static_cast<float>(i) * xScale;
-            float minY = centreY - historyEntry->previewMin[static_cast<size_t>(i)] * yScale;
-            float maxY = centreY - historyEntry->previewMax[static_cast<size_t>(i)] * yScale;
+            const auto x = waveArea.getX() + static_cast<float>(point) * xScale;
+            const auto minY = centreY - historyEntry->previewMin[static_cast<size_t>(point)] * yScale;
+            const auto maxY = centreY - historyEntry->previewMax[static_cast<size_t>(point)] * yScale;
             g.drawVerticalLine(static_cast<int>(x), std::min(minY, maxY), std::max(minY, maxY));
         }
     }
 
-    // Iteration label
-    g.setColour(juce::Colours::white.withAlpha(0.7f));
-    g.setFont(10.0f);
-    g.drawText("#" + juce::String(entryIndex + 1), bounds.reduced(4.0f, 2.0f),
-               juce::Justification::topLeft);
+    auto metaArea = bounds.reduced(8.0f, 6.0f);
+    metaArea.removeFromTop(static_cast<int>(waveArea.getBottom() - bounds.getY()) + 6);
 
-    // Root note label
+    g.setFont(juce::Font(Theme::fontSmall).boldened());
+    g.setColour(juce::Colour(Theme::textBright));
+    g.drawText("#" + juce::String(entryIndex + 1), metaArea.removeFromTop(12), juce::Justification::centredLeft);
+
+    g.setFont(juce::Font(Theme::fontMetadata));
+    g.setColour(juce::Colour(Theme::textDim));
+    g.drawText(juce::String(historyEntry->getLengthSeconds(), 1) + "s",
+               metaArea.removeFromTop(11), juce::Justification::centredLeft);
+
     if (historyEntry->rootNote.midiNote >= 0)
     {
-        g.drawText(historyEntry->rootNote.getNoteName(), bounds.reduced(4.0f, 2.0f),
-                   juce::Justification::topRight);
+        g.setColour(juce::Colour(Theme::textNormal));
+        g.drawText(historyEntry->rootNote.getNoteName(), metaArea, juce::Justification::centredRight);
     }
+}
 
-    // Duration
-    g.drawText(juce::String(historyEntry->getLengthSeconds(), 1) + "s",
-               bounds.reduced(4.0f, 2.0f), juce::Justification::bottomLeft);
+void ResamplePanel::HistoryThumbnail::mouseEnter(const juce::MouseEvent& e)
+{
+    juce::ignoreUnused(e);
+    hovered = true;
+    repaint();
+}
 
-    // Exported indicator
-    if (historyEntry->exported)
-    {
-        g.setColour(juce::Colour(Theme::accentGreen).withAlpha(0.6f));
-        g.setFont(9.0f);
-        g.drawText("EXP", bounds.reduced(4.0f, 2.0f), juce::Justification::bottomRight);
-    }
+void ResamplePanel::HistoryThumbnail::mouseExit(const juce::MouseEvent& e)
+{
+    juce::ignoreUnused(e);
+    hovered = false;
+    repaint();
 }
 
 void ResamplePanel::HistoryThumbnail::mouseDown(const juce::MouseEvent& e)
@@ -108,55 +120,56 @@ void ResamplePanel::HistoryThumbnail::setEntry(const ResampleHistoryEntry* entry
 
 ResamplePanel::ResamplePanel()
 {
-    // Resample button
     addAndMakeVisible(resampleButton);
-    resampleButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::accentGreen));
+    resampleButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonPrimary));
+    resampleButton.setColour(juce::TextButton::textColourOffId, juce::Colour(Theme::bgDarkest));
     resampleButton.onClick = [this] { if (onResample) onResample(); };
 
-    // Undo button
     addAndMakeVisible(undoButton);
+    undoButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonUtility));
     undoButton.onClick = [this] { if (onUndo) onUndo(); };
 
-    // Export button
     addAndMakeVisible(exportButton);
+    exportButton.setVisible(false);
     exportButton.onClick = [this] { if (onExportCurrent) onExportCurrent(); };
 
-    // Clear button
     addAndMakeVisible(clearButton);
+    clearButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonDestructive));
     clearButton.onClick = [this] { if (onClearHistory) onClearHistory(); };
 
-    // Capture length slider
     addAndMakeVisible(captureLengthSlider);
     captureLengthSlider.setRange(0.5, 30.0, 0.5);
     captureLengthSlider.setValue(4.0, juce::dontSendNotification);
     captureLengthSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    captureLengthSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 45, 20);
+    captureLengthSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 44, 18);
     captureLengthSlider.setTextValueSuffix("s");
+
     addAndMakeVisible(captureLengthLabel);
     captureLengthLabel.setJustificationType(juce::Justification::centredRight);
     captureLengthLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textNormal));
+    captureLengthLabel.setFont(juce::Font(Theme::fontLabel));
 
-    // Bit depth selector
     addAndMakeVisible(bitDepthSelector);
     bitDepthSelector.addItem("16-bit", 1);
     bitDepthSelector.addItem("24-bit", 2);
     bitDepthSelector.addItem("32-float", 3);
-    bitDepthSelector.setSelectedId(2, juce::dontSendNotification); // Default 24-bit
+    bitDepthSelector.setSelectedId(2, juce::dontSendNotification);
+
     addAndMakeVisible(bitDepthLabel);
     bitDepthLabel.setJustificationType(juce::Justification::centredRight);
     bitDepthLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textNormal));
+    bitDepthLabel.setFont(juce::Font(Theme::fontLabel));
 
-    // History label
     addAndMakeVisible(historyLabel);
-    historyLabel.setFont(juce::Font(14.0f).boldened());
-    historyLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::accentGreen));
+    historyLabel.setText("History", juce::dontSendNotification);
+    historyLabel.setFont(juce::Font(Theme::fontSmall).boldened());
+    historyLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textDim));
 
-    // Progress label
     addAndMakeVisible(progressLabel);
-    progressLabel.setJustificationType(juce::Justification::centred);
-    progressLabel.setColour(juce::Label::textColourId, juce::Colours::yellow);
+    progressLabel.setJustificationType(juce::Justification::centredRight);
+    progressLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textBright));
+    progressLabel.setFont(juce::Font(Theme::fontMetadata));
 
-    // History thumbnails
     for (auto& thumb : thumbnails)
     {
         addChildComponent(thumb);
@@ -164,7 +177,6 @@ ResamplePanel::ResamplePanel()
         thumb.onExport = [this](int index) { if (onExport) onExport(index); };
         thumb.onDragStart = [this](int index, const juce::MouseEvent&)
         {
-            // Drag-and-drop out: handled by parent DragAndDropContainer
             if (onExport)
                 onExport(index);
         };
@@ -175,18 +187,35 @@ void ResamplePanel::paint(juce::Graphics& g)
 {
     auto bounds = getLocalBounds().toFloat();
 
-    // Panel background
     g.setColour(juce::Colour(Theme::bgPanel));
     g.fillRoundedRectangle(bounds, Theme::cornerRadius);
 
-    // Border
     g.setColour(juce::Colour(Theme::border));
     g.drawRoundedRectangle(bounds.reduced(0.5f), Theme::cornerRadius, Theme::borderWidth);
 
-    // Capture progress bar
+    g.setColour(juce::Colour(Theme::accentGreen));
+    g.setFont(juce::Font(Theme::fontSectionHead).boldened());
+    g.drawText("RESAMPLE", 12, 6, 100, 18, juce::Justification::centredLeft);
+
+    auto historyArea = historyBounds;
+
+    g.setColour(juce::Colour(Theme::bgControl));
+    g.fillRoundedRectangle(historyArea.toFloat(), Theme::cornerRadius);
+    g.setColour(juce::Colour(Theme::borderSubtle));
+    g.drawRoundedRectangle(historyArea.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+
+    if (visibleThumbnails == 0)
+    {
+        g.setColour(juce::Colour(Theme::textDim));
+        g.setFont(juce::Font(Theme::fontValue));
+        g.drawText("Resample to start building history",
+                   historyArea.reduced(14).toFloat().toNearestInt(),
+                   juce::Justification::centred);
+    }
+
     if (captureProgress > 0.0f && captureProgress < 1.0f)
     {
-        auto progressArea = bounds.reduced(10.0f).removeFromBottom(4.0f);
+        auto progressArea = historyArea.removeFromBottom(4).reduced(14, 0).toFloat();
         g.setColour(juce::Colour(Theme::border));
         g.fillRoundedRectangle(progressArea, 2.0f);
         g.setColour(juce::Colour(Theme::accentGreen));
@@ -196,75 +225,68 @@ void ResamplePanel::paint(juce::Graphics& g)
 
 void ResamplePanel::resized()
 {
-    auto area = getLocalBounds().reduced(10);
+    auto area = getLocalBounds().reduced(Theme::panelPadding);
+    area.removeFromTop(24);
 
-    // Top row: title + resample button + undo
-    auto topRow = area.removeFromTop(28);
-    historyLabel.setBounds(topRow.removeFromLeft(160));
-    topRow.removeFromLeft(10);
-    resampleButton.setBounds(topRow.removeFromLeft(90));
-    topRow.removeFromLeft(5);
-    undoButton.setBounds(topRow.removeFromLeft(55));
-    topRow.removeFromLeft(5);
-    clearButton.setBounds(topRow.removeFromLeft(55));
-
-    area.removeFromTop(6);
-
-    // Controls row: capture length + bit depth + export
-    auto controlRow = area.removeFromTop(26);
-    captureLengthLabel.setBounds(controlRow.removeFromLeft(45));
+    auto controlRow = area.removeFromTop(28);
+    resampleButton.setBounds(controlRow.removeFromLeft(98));
+    controlRow.removeFromLeft(Theme::controlGap);
+    captureLengthLabel.setBounds(controlRow.removeFromLeft(46));
     controlRow.removeFromLeft(4);
-    captureLengthSlider.setBounds(controlRow.removeFromLeft(180));
-    controlRow.removeFromLeft(15);
-    bitDepthLabel.setBounds(controlRow.removeFromLeft(55));
+    captureLengthSlider.setBounds(controlRow.removeFromLeft(160));
+    controlRow.removeFromLeft(Theme::sectionGap);
+    bitDepthLabel.setBounds(controlRow.removeFromLeft(48));
     controlRow.removeFromLeft(4);
-    bitDepthSelector.setBounds(controlRow.removeFromLeft(90));
-    controlRow.removeFromLeft(10);
-    exportButton.setBounds(controlRow.removeFromLeft(90));
-
-    // Progress label
+    bitDepthSelector.setBounds(controlRow.removeFromLeft(92));
     progressLabel.setBounds(controlRow);
 
-    area.removeFromTop(8);
+    area.removeFromTop(Theme::sectionGap);
+    historyLabel.setBounds(area.removeFromTop(16));
+    area.removeFromTop(4);
 
-    // History thumbnails — horizontal strip
-    auto historyArea = area;
-    int thumbWidth = (historyArea.getWidth() - 7 * 4) / 8; // 4px gap between thumbnails
-    int thumbHeight = historyArea.getHeight();
+    auto actionsRow = area.removeFromBottom(28);
+    undoButton.setBounds(actionsRow.removeFromLeft(72));
+    clearButton.setBounds(actionsRow.removeFromRight(72));
 
-    for (int i = 0; i < 8; ++i)
+    area.removeFromBottom(Theme::controlGap);
+    historyBounds = area;
+
+    const int gap = Theme::controlGap;
+    const int thumbCount = 8;
+    const int thumbWidth = (historyBounds.getWidth() - gap * (thumbCount - 1) - 20) / thumbCount;
+    const int thumbHeight = historyBounds.getHeight() - 20;
+    auto thumbArea = historyBounds.reduced(10, 10);
+
+    for (int index = 0; index < 8; ++index)
     {
-        auto thumbBounds = historyArea.removeFromLeft(thumbWidth);
-        thumbnails[static_cast<size_t>(i)].setBounds(thumbBounds.withHeight(thumbHeight));
-        if (i < 7)
-            historyArea.removeFromLeft(4);
+        const int x = thumbArea.getX() + index * (thumbWidth + gap);
+        thumbnails[static_cast<size_t>(index)].setBounds(x, thumbArea.getY(), thumbWidth, thumbHeight);
     }
 }
 
 void ResamplePanel::updateFromEngine(ResampleEngine& engine)
 {
-    int count = engine.getHistorySize();
-    int current = engine.getCurrentIndex();
+    const auto count = engine.getHistorySize();
+    const auto current = engine.getCurrentIndex();
     visibleThumbnails = count;
 
-    for (int i = 0; i < 8; ++i)
+    for (int index = 0; index < 8; ++index)
     {
-        if (i < count)
+        if (index < count)
         {
-            thumbnails[static_cast<size_t>(i)].setEntry(engine.getHistoryEntry(i), i, i == current);
-            thumbnails[static_cast<size_t>(i)].setVisible(true);
+            thumbnails[static_cast<size_t>(index)].setEntry(engine.getHistoryEntry(index), index, index == current);
+            thumbnails[static_cast<size_t>(index)].setVisible(true);
         }
         else
         {
-            thumbnails[static_cast<size_t>(i)].setEntry(nullptr, -1, false);
-            thumbnails[static_cast<size_t>(i)].setVisible(false);
+            thumbnails[static_cast<size_t>(index)].setEntry(nullptr, -1, false);
+            thumbnails[static_cast<size_t>(index)].setVisible(false);
         }
     }
 
-    // Update button states
     undoButton.setEnabled(current > 0);
-    exportButton.setEnabled(count > 0);
     clearButton.setEnabled(count > 0);
+    repaint();
 }
 
 void ResamplePanel::setCaptureProgress(float progress)
@@ -275,7 +297,7 @@ void ResamplePanel::setCaptureProgress(float progress)
     {
         resampleButton.setEnabled(false);
         progressLabel.setText("Capturing " + juce::String(static_cast<int>(progress * 100.0f)) + "%",
-                             juce::dontSendNotification);
+                              juce::dontSendNotification);
     }
     else
     {

--- a/Source/UI/ResamplePanel.h
+++ b/Source/UI/ResamplePanel.h
@@ -55,6 +55,8 @@ private:
     public:
         HistoryThumbnail();
         void paint(juce::Graphics& g) override;
+        void mouseEnter(const juce::MouseEvent& e) override;
+        void mouseExit(const juce::MouseEvent& e) override;
         void mouseDown(const juce::MouseEvent& e) override;
         void mouseDrag(const juce::MouseEvent& e) override;
 
@@ -68,6 +70,7 @@ private:
         const ResampleHistoryEntry* historyEntry = nullptr;
         int entryIndex = -1;
         bool current = false;
+        bool hovered = false;
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HistoryThumbnail)
     };
@@ -92,6 +95,7 @@ private:
     int visibleThumbnails = 0;
 
     float captureProgress = 0.0f;
+    juce::Rectangle<int> historyBounds;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ResamplePanel)
 };

--- a/Source/UI/SampleBrowser.h
+++ b/Source/UI/SampleBrowser.h
@@ -28,13 +28,25 @@ public:
         categoryLabel.setText("Category", juce::dontSendNotification);
         categoryLabel.setJustificationType(juce::Justification::centredRight);
         categoryLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::textDim));
+        categoryLabel.setFont(juce::Font(Theme::fontSmall));
 
         // Sample list
         addAndMakeVisible(listBox);
         listBox.setModel(this);
-        listBox.setRowHeight(28);
+        listBox.setRowHeight(32);
         listBox.setColour(juce::ListBox::backgroundColourId, juce::Colour(Theme::bgControl));
         listBox.setColour(juce::ListBox::outlineColourId, juce::Colour(Theme::border));
+        listBox.addMouseListener(this, true);
+
+        // Import button
+        addAndMakeVisible(importButton);
+        importButton.setButtonText("Import WAV");
+        importButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonUtility));
+        importButton.onClick = [this]
+        {
+            if (onImportSample)
+                onImportSample();
+        };
 
         // Load button
         addAndMakeVisible(loadButton);
@@ -51,6 +63,7 @@ public:
         // Preview button
         addAndMakeVisible(previewButton);
         previewButton.setButtonText("Preview");
+        previewButton.setColour(juce::TextButton::buttonColourId, juce::Colour(Theme::buttonSecondary));
         previewButton.onClick = [this]
         {
             int selected = listBox.getSelectedRow();
@@ -60,7 +73,7 @@ public:
 
         // Title
         addAndMakeVisible(titleLabel);
-        titleLabel.setText("BROWSER", juce::dontSendNotification);
+        titleLabel.setText("FACTORY LIBRARY", juce::dontSendNotification);
         titleLabel.setFont(juce::Font(Theme::fontSectionHead).boldened());
         titleLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::accentOrange));
 
@@ -105,6 +118,22 @@ public:
         listBox.repaint();
     }
 
+    void setLoadedSample(const juce::String& name, const juce::String& category)
+    {
+        loadedSampleName = name;
+        loadedSampleCategory = category;
+        hasLoadedFactorySample = true;
+        listBox.repaint();
+    }
+
+    void clearLoadedSample()
+    {
+        loadedSampleName.clear();
+        loadedSampleCategory.clear();
+        hasLoadedFactorySample = false;
+        listBox.repaint();
+    }
+
     // ListBoxModel
     int getNumRows() override { return static_cast<int>(filteredSamples.size()); }
 
@@ -116,15 +145,31 @@ public:
 
         auto& sample = filteredSamples[static_cast<size_t>(rowNumber)];
 
+        const bool isHovered = rowNumber == hoveredRow;
+        const bool isLoaded = hasLoadedFactorySample
+            && sample.name == loadedSampleName
+            && sample.category == loadedSampleCategory;
+
         if (rowIsSelected)
+            g.fillAll(juce::Colour(Theme::bgElevated));
+        else if (isHovered)
             g.fillAll(juce::Colour(Theme::bgHover));
 
+        if (rowIsSelected || isLoaded)
+        {
+            g.setColour(juce::Colour(Theme::accentOrange));
+            g.fillRect(0, 2, 3, height - 4);
+        }
+
         g.setColour(juce::Colour(Theme::textNormal));
-        g.setFont(12.0f);
+        auto rowFont = juce::Font(Theme::fontValue);
+        if (isLoaded)
+            rowFont = rowFont.boldened();
+        g.setFont(rowFont);
         g.drawText(sample.name, 8, 0, width - 80, height, juce::Justification::centredLeft);
 
         g.setColour(juce::Colour(Theme::textDim));
-        g.setFont(10.0f);
+        g.setFont(juce::Font(Theme::fontSmall));
         g.drawText(sample.category, width - 75, 0, 70, height, juce::Justification::centredRight);
     }
 
@@ -144,32 +189,55 @@ public:
                                Theme::cornerRadius, Theme::borderWidth);
     }
 
+    void mouseMove(const juce::MouseEvent& e) override
+    {
+        auto point = e.getEventRelativeTo(&listBox).position;
+        auto row = listBox.getRowContainingPosition(static_cast<int>(point.x), static_cast<int>(point.y));
+        if (row != hoveredRow)
+        {
+            hoveredRow = row;
+            listBox.repaint();
+        }
+    }
+
+    void mouseExit(const juce::MouseEvent&) override
+    {
+        if (hoveredRow >= 0)
+        {
+            hoveredRow = -1;
+            listBox.repaint();
+        }
+    }
+
     void resized() override
     {
         auto area = getLocalBounds().reduced(Theme::panelPadding);
 
         auto titleRow = area.removeFromTop(22);
         titleLabel.setBounds(titleRow);
-        area.removeFromTop(4);
+        area.removeFromTop(Theme::controlGap);
 
-        auto filterRow = area.removeFromTop(24);
+        auto filterRow = area.removeFromTop(26);
         categoryLabel.setBounds(filterRow.removeFromLeft(60));
-        filterRow.removeFromLeft(4);
+        filterRow.removeFromLeft(Theme::controlGap);
         categoryBox.setBounds(filterRow);
-        area.removeFromTop(4);
+        area.removeFromTop(Theme::controlGap);
 
-        auto buttonRow = area.removeFromBottom(28);
-        loadButton.setBounds(buttonRow.removeFromRight(60));
-        buttonRow.removeFromRight(4);
-        previewButton.setBounds(buttonRow.removeFromRight(65));
+        auto buttonRow = area.removeFromBottom(30);
+        importButton.setBounds(buttonRow.removeFromLeft(92));
+        buttonRow.removeFromLeft(Theme::controlGap);
+        previewButton.setBounds(buttonRow.removeFromLeft(74));
+        buttonRow.removeFromLeft(Theme::controlGap);
+        loadButton.setBounds(buttonRow.removeFromLeft(64));
 
-        area.removeFromBottom(4);
+        area.removeFromBottom(Theme::controlGap);
         listBox.setBounds(area);
     }
 
     // Callbacks
     std::function<void(const FactorySample&)> onLoadSample;
     std::function<void(const FactorySample&)> onPreviewSample;
+    std::function<void()> onImportSample;
 
     // Get a factory sample to use as initial default sound
     const FactorySample* getDefaultSample() const
@@ -186,8 +254,13 @@ private:
     juce::ComboBox categoryBox;
     juce::Label categoryLabel;
     juce::ListBox listBox;
+    juce::TextButton importButton;
     juce::TextButton loadButton;
     juce::TextButton previewButton;
+    int hoveredRow = -1;
+    juce::String loadedSampleName;
+    juce::String loadedSampleCategory;
+    bool hasLoadedFactorySample = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SampleBrowser)
 };

--- a/Source/UI/SubPanel.cpp
+++ b/Source/UI/SubPanel.cpp
@@ -5,7 +5,7 @@ namespace grainhex {
 static void styleRotarySlider(juce::Slider& slider, double min, double max, double defaultVal, double interval = 0.0)
 {
     slider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-    slider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 60, 16);
+    slider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 64, 16);
     slider.setRange(min, max, interval);
     slider.setValue(defaultVal, juce::dontSendNotification);
     slider.setColour(juce::Slider::rotarySliderFillColourId, juce::Colour(Theme::accentPurple));
@@ -16,7 +16,7 @@ static void styleRotarySlider(juce::Slider& slider, double min, double max, doub
 
 static void styleLabel(juce::Label& label)
 {
-    label.setJustificationType(juce::Justification::centred);
+    label.setJustificationType(juce::Justification::centredLeft);
     label.setColour(juce::Label::textColourId, juce::Colour(Theme::textNormal));
     label.setFont(juce::Font(Theme::fontLabel));
 }
@@ -30,18 +30,21 @@ static void styleComboBox(juce::ComboBox& box)
 
 SubPanel::SubPanel()
 {
-    // Enable toggle
     addAndMakeVisible(enableToggle);
+    enableToggle.setButtonText("Enabled");
     enableToggle.setToggleState(false, juce::dontSendNotification);
     enableToggle.setColour(juce::ToggleButton::tickColourId, juce::Colour(Theme::accentPurple));
-    enableToggle.onClick = [this] { parameterChanged(); };
+    enableToggle.onClick = [this]
+    {
+        updateContentAlpha();
+        parameterChanged();
+        repaint();
+    };
 
-    // Level: 0-1, default 0.7
     styleRotarySlider(levelSlider, 0.0, 1.0, 0.7, 0.01);
     addAndMakeVisible(levelSlider);
     levelSlider.onValueChange = [this] { parameterChanged(); };
 
-    // Waveform
     waveformBox.addItem("Sine", 1);
     waveformBox.addItem("Triangle", 2);
     waveformBox.setSelectedId(1, juce::dontSendNotification);
@@ -49,15 +52,18 @@ SubPanel::SubPanel()
     addAndMakeVisible(waveformBox);
     waveformBox.onChange = [this] { parameterChanged(); };
 
-    // Mode (Auto/Manual)
     modeBox.addItem("Auto", 1);
     modeBox.addItem("Manual", 2);
     modeBox.setSelectedId(1, juce::dontSendNotification);
     styleComboBox(modeBox);
     addAndMakeVisible(modeBox);
-    modeBox.onChange = [this] { updateModeVisibility(); parameterChanged(); };
+    modeBox.onChange = [this]
+    {
+        updateModeVisibility();
+        resized();
+        parameterChanged();
+    };
 
-    // Pitch snap mode (Strict/Loose) — Auto mode only
     snapModeBox.addItem("Strict", 1);
     snapModeBox.addItem("Loose", 2);
     snapModeBox.setSelectedId(1, juce::dontSendNotification);
@@ -65,7 +71,6 @@ SubPanel::SubPanel()
     addAndMakeVisible(snapModeBox);
     snapModeBox.onChange = [this] { parameterChanged(); };
 
-    // Smoothing speed — Auto mode only
     smoothingBox.addItem("Slow", 1);
     smoothingBox.addItem("Medium", 2);
     smoothingBox.addItem("Fast", 3);
@@ -74,46 +79,39 @@ SubPanel::SubPanel()
     addAndMakeVisible(smoothingBox);
     smoothingBox.onChange = [this] { parameterChanged(); };
 
-    // Note selector (C0-B3) — Manual mode only
     static const char* noteNames[] = { "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B" };
     int itemId = 1;
     for (int octave = 0; octave <= 3; ++octave)
-    {
         for (int note = 0; note < 12; ++note)
-        {
-            juce::String name = juce::String(noteNames[note]) + juce::String(octave);
-            noteBox.addItem(name, itemId++);
-        }
-    }
-    noteBox.setSelectedId(25, juce::dontSendNotification); // C2 default (index 25 = MIDI 36)
+            noteBox.addItem(juce::String(noteNames[note]) + juce::String(octave), itemId++);
+    noteBox.setSelectedId(25, juce::dontSendNotification);
     styleComboBox(noteBox);
     addAndMakeVisible(noteBox);
     noteBox.onChange = [this] { parameterChanged(); };
 
-    // Octave offset
     octaveOffsetBox.addItem("-2", 1);
     octaveOffsetBox.addItem("-1", 2);
     octaveOffsetBox.addItem("0", 3);
-    octaveOffsetBox.setSelectedId(2, juce::dontSendNotification); // Default -1
+    octaveOffsetBox.setSelectedId(2, juce::dontSendNotification);
     styleComboBox(octaveOffsetBox);
     addAndMakeVisible(octaveOffsetBox);
     octaveOffsetBox.onChange = [this] { parameterChanged(); };
 
-    // Granular HP filter frequency
     styleRotarySlider(granularHPSlider, 20.0, 300.0, 100.0, 1.0);
     granularHPSlider.setTextValueSuffix(" Hz");
     granularHPSlider.setSkewFactorFromMidPoint(100.0);
     addAndMakeVisible(granularHPSlider);
     granularHPSlider.onValueChange = [this] { parameterChanged(); };
 
-    // Sub LP filter frequency
     styleRotarySlider(subLPSlider, 40.0, 400.0, 200.0, 1.0);
     subLPSlider.setTextValueSuffix(" Hz");
     subLPSlider.setSkewFactorFromMidPoint(200.0);
     addAndMakeVisible(subLPSlider);
     subLPSlider.onValueChange = [this] { parameterChanged(); };
 
-    // Labels
+    granularHPLabel.setText("Grain Highpass", juce::dontSendNotification);
+    subLPLabel.setText("Sub Lowpass", juce::dontSendNotification);
+
     for (auto* label : { &levelLabel, &waveformLabel, &modeLabel, &snapModeLabel,
                           &smoothingLabel, &noteLabel, &octaveOffsetLabel,
                           &granularHPLabel, &subLPLabel })
@@ -122,15 +120,14 @@ SubPanel::SubPanel()
         addAndMakeVisible(label);
     }
 
-    // Pitch display
     addAndMakeVisible(pitchNoteLabel);
     pitchNoteLabel.setJustificationType(juce::Justification::centred);
     pitchNoteLabel.setColour(juce::Label::textColourId, juce::Colour(Theme::accentPurple));
-    pitchNoteLabel.setFont(juce::Font(22.0f).boldened());
+    pitchNoteLabel.setFont(juce::Font(Theme::fontTitle + 12.0f).boldened());
     pitchNoteLabel.setText("---", juce::dontSendNotification);
 
-    // Initial mode visibility
     updateModeVisibility();
+    updateContentAlpha();
 }
 
 void SubPanel::paint(juce::Graphics& g)
@@ -143,121 +140,219 @@ void SubPanel::paint(juce::Graphics& g)
 
     g.setColour(juce::Colour(Theme::accentPurple));
     g.setFont(juce::Font(Theme::fontSectionHead).boldened());
-    g.drawText("SUB TUNER", 10, 4, 120, 20, juce::Justification::centredLeft);
+    g.drawText("SUB TUNER", 12, 6, 120, 18, juce::Justification::centredLeft);
 
-    // Draw cents bar next to pitch note label
-    auto pitchArea = pitchNoteLabel.getBounds();
-    int barX = pitchArea.getRight() + 8;
-    int barY = pitchArea.getCentreY() - 15;
-    int barW = 60;
-    int barH = 30;
+    auto drawGroup = [&](juce::Rectangle<int> bounds, const juce::String& title)
+    {
+        g.setColour(juce::Colour(Theme::bgControl));
+        g.fillRoundedRectangle(bounds.toFloat(), Theme::cornerRadius);
+        g.setColour(juce::Colour(Theme::borderSubtle));
+        g.drawRoundedRectangle(bounds.toFloat().reduced(0.5f), Theme::cornerRadius, 1.0f);
+        g.setColour(juce::Colour(Theme::textDim));
+        g.setFont(juce::Font(Theme::fontSmall).boldened());
+        g.drawText(title, bounds.getX() + 10, bounds.getY() + 8, bounds.getWidth() - 20, 14,
+                   juce::Justification::centredLeft);
+    };
 
-    // Background bar
-    g.setColour(juce::Colour(Theme::bgControl));
-    g.fillRect(barX, barY, barW, barH);
+    const auto contentAlpha = enableToggle.getToggleState() ? 1.0f : 0.4f;
+    juce::Graphics::ScopedSaveState savedState(g);
+    g.setOpacity(contentAlpha);
+
+    drawGroup(pitchDisplayBounds, "Pitch Display");
+    drawGroup(levelGroupBounds, "Level + Wave");
+    drawGroup(modeGroupBounds, "Pitch + Mode");
+    drawGroup(crossoverGroupBounds, "Crossover");
+
+    auto display = pitchDisplayBounds.reduced(16, 18);
+    display.removeFromTop(16);
+
+    auto noteCard = display.removeFromTop(78).withSizeKeepingCentre(120, 72);
+    g.setColour(juce::Colour(Theme::bgDarkest));
+    g.fillRoundedRectangle(noteCard.toFloat(), 10.0f);
+    g.setColour(juce::Colour(Theme::borderActive));
+    g.drawRoundedRectangle(noteCard.toFloat().reduced(0.5f), 10.0f, 1.0f);
+
+    auto centsText = (pitchConfidence > 0.0f ? juce::String(pitchCents >= 0.0f ? "+" : "")
+                                               + juce::String(static_cast<int>(std::round(pitchCents))) + "ct"
+                                             : juce::String("--"));
+    g.setColour(juce::Colour(Theme::textDim));
+    g.setFont(juce::Font(Theme::fontValue));
+    g.drawText(centsText, noteCard.getX(), noteCard.getBottom() - 22, noteCard.getWidth(), 16,
+               juce::Justification::centred);
+
+    auto centsBar = display.removeFromTop(18);
+    const auto barBounds = centsBar.withTrimmedLeft(8).withTrimmedRight(8).withHeight(8);
+    g.setColour(juce::Colour(Theme::bgDarkest));
+    g.fillRoundedRectangle(barBounds.toFloat(), 4.0f);
     g.setColour(juce::Colour(Theme::border));
-    g.drawRect(barX, barY, barW, barH, 1);
-
-    // Center line
-    int centerX = barX + barW / 2;
+    g.drawRoundedRectangle(barBounds.toFloat(), 4.0f, 1.0f);
     g.setColour(juce::Colour(Theme::textMuted));
-    g.drawVerticalLine(centerX, static_cast<float>(barY), static_cast<float>(barY + barH));
+    g.drawLine(static_cast<float>(barBounds.getCentreX()), static_cast<float>(barBounds.getY()),
+               static_cast<float>(barBounds.getCentreX()), static_cast<float>(barBounds.getBottom()), 1.0f);
 
-    // Cents indicator
     if (pitchConfidence > 0.3f)
     {
-        float centsNorm = juce::jlimit(-50.0f, 50.0f, pitchCents) / 50.0f;
-        int indicatorX = centerX + static_cast<int>(centsNorm * (barW / 2 - 2));
+        const auto centsNorm = juce::jlimit(-50.0f, 50.0f, pitchCents) / 50.0f;
+        const auto indicatorX = static_cast<float>(barBounds.getCentreX()) + centsNorm * (static_cast<float>(barBounds.getWidth()) * 0.5f - 6.0f);
         g.setColour(juce::Colour(Theme::accentPurple));
-        g.fillRect(indicatorX - 1, barY + 2, 3, barH - 4);
+        g.fillRoundedRectangle(indicatorX - 4.0f, static_cast<float>(barBounds.getY()) + 1.0f, 8.0f,
+                               static_cast<float>(barBounds.getHeight()) - 2.0f, 4.0f);
     }
 
-    // Confidence indicator
-    g.setFont(Theme::fontSmall);
-    g.setColour(pitchConfidence > 0.5f ? juce::Colour(Theme::accentGreen) : juce::Colour(Theme::textMuted));
-    g.drawText(juce::String(static_cast<int>(pitchConfidence * 100.0f)) + "%",
-               barX, barY + barH + 2, barW, 14, juce::Justification::centred);
+    auto confidenceBounds = display.withTrimmedTop(8).removeFromTop(16);
+    g.setColour(juce::Colour(Theme::textDim));
+    g.setFont(juce::Font(Theme::fontMetadata));
+    g.drawText("Confidence", confidenceBounds.removeFromTop(10), juce::Justification::centredLeft);
+    auto confidenceBar = confidenceBounds.removeFromTop(5).withWidth(juce::jmax(12, confidenceBounds.getWidth() - 10));
+    g.setColour(juce::Colour(Theme::bgDarkest));
+    g.fillRoundedRectangle(confidenceBar.toFloat(), 2.5f);
+    g.setColour(juce::Colour(Theme::accentGreen).withAlpha(0.85f));
+    g.fillRoundedRectangle(confidenceBar.withWidth(static_cast<int>(static_cast<float>(confidenceBar.getWidth()) * pitchConfidence)).toFloat(), 2.5f);
+    g.setColour(juce::Colour(Theme::textBright));
+    g.drawText(juce::String(static_cast<int>(pitchConfidence * 100.0f)) + "%", confidenceBar.translated(0, 6),
+               juce::Justification::centredLeft);
 }
 
 void SubPanel::resized()
 {
-    auto area = getLocalBounds().reduced(8);
-    area.removeFromTop(22); // Header space
+    auto area = getLocalBounds().reduced(Theme::panelPadding);
+    area.removeFromTop(24);
 
-    const int knobW = 65;
-    const int knobH = 65;
+    auto toggleRow = area.removeFromTop(20);
+    enableToggle.setBounds(toggleRow.removeFromLeft(86));
+    area.removeFromTop(Theme::sectionGap);
+
+    auto leftColumn = area.removeFromLeft(static_cast<int>(area.getWidth() * 0.42f));
+    area.removeFromLeft(Theme::sectionGap);
+    auto rightColumn = area;
+
+    pitchDisplayBounds = leftColumn;
+    auto displayLayout = pitchDisplayBounds.reduced(16, 18);
+    displayLayout.removeFromTop(16);
+    auto noteCard = displayLayout.removeFromTop(78).withSizeKeepingCentre(120, 72);
+    pitchNoteLabel.setBounds(noteCard.withTrimmedBottom(18));
+
+    auto topRight = rightColumn.removeFromTop(static_cast<int>(rightColumn.getHeight() * 0.58f));
+    levelGroupBounds = topRight.removeFromLeft(static_cast<int>(topRight.getWidth() * 0.38f));
+    topRight.removeFromLeft(Theme::sectionGap);
+    modeGroupBounds = topRight;
+    rightColumn.removeFromTop(Theme::sectionGap);
+    crossoverGroupBounds = rightColumn;
+
     const int labelH = 14;
-    const int comboH = 22;
-    const int comboW = 80;
-    const int gap = 4;
+    const int comboH = 24;
+    const int knobSliderH = Theme::knobSize + 18;
 
-    // Row 1: Enable toggle, Level knob, Pitch display, Gran HP, Sub LP knobs
-    auto row1 = area.removeFromTop(knobH + labelH + gap);
-
-    // Enable toggle
-    enableToggle.setBounds(row1.removeFromLeft(60).withHeight(24).withY(row1.getY() + 10));
-    row1.removeFromLeft(gap);
-
-    // Level knob
-    levelLabel.setBounds(row1.getX(), row1.getY(), knobW, labelH);
-    levelSlider.setBounds(row1.getX(), row1.getY() + labelH, knobW, knobH);
-    row1.removeFromLeft(knobW + gap);
-
-    // Pitch display (note name + cents bar area)
-    auto pitchDisplayArea = row1.removeFromLeft(140);
-    pitchNoteLabel.setBounds(pitchDisplayArea.getX(), pitchDisplayArea.getY() + 5,
-                             60, 40);
-    // Cents bar is painted in paint()
-
-    row1.removeFromLeft(gap);
-
-    // Gran HP knob
-    granularHPLabel.setBounds(row1.getX(), row1.getY(), knobW, labelH);
-    granularHPSlider.setBounds(row1.getX(), row1.getY() + labelH, knobW, knobH);
-    row1.removeFromLeft(knobW + gap);
-
-    // Sub LP knob
-    subLPLabel.setBounds(row1.getX(), row1.getY(), knobW, labelH);
-    subLPSlider.setBounds(row1.getX(), row1.getY() + labelH, knobW, knobH);
-
-    area.removeFromTop(gap);
-
-    // Row 2: Combo boxes — Waveform, Mode, Snap/Note, Smoothing, Octave
-    auto row2 = area.removeFromTop(comboH + labelH + gap);
-    int cx = row2.getX();
-    int comboGap = 8;
-
-    struct ComboPair { juce::ComboBox* box; juce::Label* label; };
-    ComboPair combos[] = {
-        { &waveformBox, &waveformLabel },
-        { &modeBox, &modeLabel },
-        { &snapModeBox, &snapModeLabel },
-        { &smoothingBox, &smoothingLabel },
-        { &noteBox, &noteLabel },
-        { &octaveOffsetBox, &octaveOffsetLabel }
-    };
-
-    for (auto& cp : combos)
     {
-        cp.label->setBounds(cx, row2.getY(), comboW, labelH);
-        cp.box->setBounds(cx, row2.getY() + labelH, comboW, comboH);
-        cx += comboW + comboGap;
+        auto levelArea = levelGroupBounds.reduced(10, 10);
+        levelArea.removeFromTop(18);
+        levelLabel.setBounds(levelArea.removeFromTop(labelH));
+        levelSlider.setBounds(levelArea.removeFromTop(knobSliderH));
+        levelArea.removeFromTop(2);
+        waveformLabel.setBounds(levelArea.removeFromTop(labelH));
+        waveformBox.setBounds(levelArea.removeFromTop(comboH));
+    }
+
+    {
+        auto modeArea = modeGroupBounds.reduced(10, 10);
+        modeArea.removeFromTop(18);
+        modeLabel.setBounds(modeArea.removeFromTop(labelH));
+        modeBox.setBounds(modeArea.removeFromTop(comboH));
+        modeArea.removeFromTop(6);
+
+        auto upperRow = modeArea.removeFromTop(labelH + comboH + 4);
+        auto lowerRow = modeArea.removeFromTop(labelH + comboH + 4);
+        const int halfWidth = (upperRow.getWidth() - Theme::controlGap) / 2;
+
+        if (modeBox.getSelectedId() == 1)
+        {
+            auto snapArea = upperRow.removeFromLeft(halfWidth);
+            upperRow.removeFromLeft(Theme::controlGap);
+            auto smoothArea = upperRow;
+
+            snapModeLabel.setBounds(snapArea.removeFromTop(labelH));
+            snapModeBox.setBounds(snapArea.removeFromTop(comboH));
+            smoothingLabel.setBounds(smoothArea.removeFromTop(labelH));
+            smoothingBox.setBounds(smoothArea.removeFromTop(comboH));
+
+            noteLabel.setBounds(juce::Rectangle<int>());
+            noteBox.setBounds(juce::Rectangle<int>());
+            octaveOffsetLabel.setBounds(juce::Rectangle<int>());
+            octaveOffsetBox.setBounds(juce::Rectangle<int>());
+        }
+        else
+        {
+            auto noteArea = upperRow.removeFromLeft(halfWidth);
+            upperRow.removeFromLeft(Theme::controlGap);
+            auto octaveArea = upperRow;
+
+            noteLabel.setBounds(noteArea.removeFromTop(labelH));
+            noteBox.setBounds(noteArea.removeFromTop(comboH));
+            octaveOffsetLabel.setBounds(octaveArea.removeFromTop(labelH));
+            octaveOffsetBox.setBounds(octaveArea.removeFromTop(comboH));
+
+            snapModeLabel.setBounds(juce::Rectangle<int>());
+            snapModeBox.setBounds(juce::Rectangle<int>());
+            smoothingLabel.setBounds(juce::Rectangle<int>());
+            smoothingBox.setBounds(juce::Rectangle<int>());
+        }
+    }
+
+    {
+        auto crossoverArea = crossoverGroupBounds.reduced(10, 10);
+        crossoverArea.removeFromTop(18);
+        const int knobWidth = (crossoverArea.getWidth() - Theme::controlGap) / 2;
+
+        auto hpArea = crossoverArea.removeFromLeft(knobWidth);
+        crossoverArea.removeFromLeft(Theme::controlGap);
+        auto lpArea = crossoverArea;
+
+        granularHPLabel.setBounds(hpArea.removeFromTop(labelH));
+        granularHPSlider.setBounds(hpArea.removeFromTop(knobSliderH));
+
+        subLPLabel.setBounds(lpArea.removeFromTop(labelH));
+        subLPSlider.setBounds(lpArea.removeFromTop(knobSliderH));
     }
 }
 
 void SubPanel::updateModeVisibility()
 {
-    bool isAuto = (modeBox.getSelectedId() == 1);
-
-    // Auto-mode controls
+    const bool isAuto = (modeBox.getSelectedId() == 1);
     snapModeBox.setVisible(isAuto);
     snapModeLabel.setVisible(isAuto);
     smoothingBox.setVisible(isAuto);
     smoothingLabel.setVisible(isAuto);
-
-    // Manual-mode controls
     noteBox.setVisible(!isAuto);
     noteLabel.setVisible(!isAuto);
+    octaveOffsetBox.setVisible(!isAuto);
+    octaveOffsetLabel.setVisible(!isAuto);
+}
+
+void SubPanel::updateContentAlpha()
+{
+    const auto alpha = enableToggle.getToggleState() ? 1.0f : 0.4f;
+    for (auto* component : { static_cast<juce::Component*>(&levelSlider),
+                             static_cast<juce::Component*>(&levelLabel),
+                             static_cast<juce::Component*>(&waveformBox),
+                             static_cast<juce::Component*>(&waveformLabel),
+                             static_cast<juce::Component*>(&modeBox),
+                             static_cast<juce::Component*>(&modeLabel),
+                             static_cast<juce::Component*>(&snapModeBox),
+                             static_cast<juce::Component*>(&snapModeLabel),
+                             static_cast<juce::Component*>(&smoothingBox),
+                             static_cast<juce::Component*>(&smoothingLabel),
+                             static_cast<juce::Component*>(&noteBox),
+                             static_cast<juce::Component*>(&noteLabel),
+                             static_cast<juce::Component*>(&octaveOffsetBox),
+                             static_cast<juce::Component*>(&octaveOffsetLabel),
+                             static_cast<juce::Component*>(&granularHPSlider),
+                             static_cast<juce::Component*>(&granularHPLabel),
+                             static_cast<juce::Component*>(&subLPSlider),
+                             static_cast<juce::Component*>(&subLPLabel),
+                             static_cast<juce::Component*>(&pitchNoteLabel) })
+    {
+        component->setAlpha(alpha);
+    }
 }
 
 void SubPanel::parameterChanged()
@@ -271,7 +366,7 @@ void SubPanel::setDetectedPitch(const PitchInfo& pitch)
     pitchNoteLabel.setText(pitch.getNoteName(), juce::dontSendNotification);
     pitchCents = pitch.centsOffset;
     pitchConfidence = pitch.confidence;
-    repaint(); // Repaint cents bar
+    repaint();
 }
 
 bool SubPanel::getEnabled() const { return enableToggle.getToggleState(); }
@@ -314,10 +409,10 @@ int SubPanel::getOctaveOffset() const
 
 int SubPanel::getManualMidiNote() const
 {
-    // noteBox items are 1-indexed, representing C0 (MIDI 12) through B3 (MIDI 59)
-    int selectedId = noteBox.getSelectedId();
-    if (selectedId < 1) return 36; // C2 default
-    return 11 + selectedId; // Item 1 = C0 = MIDI 12
+    const auto selectedId = noteBox.getSelectedId();
+    if (selectedId < 1)
+        return 36;
+    return 11 + selectedId;
 }
 
 float SubPanel::getGranularHPFreq() const { return static_cast<float>(granularHPSlider.getValue()); }

--- a/Source/UI/SubPanel.h
+++ b/Source/UI/SubPanel.h
@@ -44,6 +44,7 @@ public:
 private:
     void parameterChanged();
     void updateModeVisibility();
+    void updateContentAlpha();
 
     // Controls
     juce::ToggleButton enableToggle { "Sub" };
@@ -79,6 +80,11 @@ private:
     juce::Label pitchNoteLabel;
     float pitchCents = 0.0f;
     float pitchConfidence = 0.0f;
+
+    juce::Rectangle<int> pitchDisplayBounds;
+    juce::Rectangle<int> levelGroupBounds;
+    juce::Rectangle<int> modeGroupBounds;
+    juce::Rectangle<int> crossoverGroupBounds;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SubPanel)
 };

--- a/Source/UI/WaveformView.cpp
+++ b/Source/UI/WaveformView.cpp
@@ -4,19 +4,24 @@ namespace grainhex {
 
 WaveformView::WaveformView()
 {
-    startTimerHz(30); // 30fps playhead updates
+    startTimerHz(30);
 }
 
 void WaveformView::setSource(std::shared_ptr<juce::AudioBuffer<float>> buffer, double sampleRate)
 {
-    sourceBuffer = buffer;
+    sourceBuffer = std::move(buffer);
     sourceSampleRate = sampleRate;
-    totalSamples = buffer ? buffer->getNumSamples() : 0;
+    totalSamples = sourceBuffer ? sourceBuffer->getNumSamples() : 0;
 
-    if (buffer)
+    if (sourceBuffer != nullptr)
     {
         loopStartSample = 0;
         loopEndSample = totalSamples;
+    }
+    else
+    {
+        loopStartSample = 0;
+        loopEndSample = 0;
     }
 
     generatePeakData();
@@ -47,106 +52,236 @@ void WaveformView::generatePeakData()
     if (sourceBuffer == nullptr || totalSamples == 0 || getWidth() <= 0)
         return;
 
-    int numPixels = getWidth();
+    const auto waveBounds = getWaveBounds();
+    const auto numPixels = juce::jmax(1, static_cast<int>(waveBounds.getWidth()));
     peaks.resize(static_cast<size_t>(numPixels));
 
-    double samplesPerPixel = static_cast<double>(totalSamples) / static_cast<double>(numPixels);
+    const auto samplesPerPixel = static_cast<double>(totalSamples) / static_cast<double>(numPixels);
+    const auto numChannels = juce::jmin(2, sourceBuffer->getNumChannels());
 
     for (int px = 0; px < numPixels; ++px)
     {
-        int64_t startIdx = static_cast<int64_t>(px * samplesPerPixel);
-        int64_t endIdx = static_cast<int64_t>((px + 1) * samplesPerPixel);
-        endIdx = std::min(endIdx, totalSamples);
+        PeakData peak;
+        peak.numChannels = numChannels;
 
-        float minVal = 0.0f;
-        float maxVal = 0.0f;
-
-        for (int ch = 0; ch < sourceBuffer->getNumChannels(); ++ch)
+        for (int channel = 0; channel < numChannels; ++channel)
         {
-            const float* data = sourceBuffer->getReadPointer(ch);
-            for (int64_t i = startIdx; i < endIdx; ++i)
-            {
-                float s = data[i];
-                minVal = std::min(minVal, s);
-                maxVal = std::max(maxVal, s);
-            }
+            peak.minVals[static_cast<size_t>(channel)] = 0.0f;
+            peak.maxVals[static_cast<size_t>(channel)] = 0.0f;
         }
 
-        peaks[static_cast<size_t>(px)] = { minVal, maxVal };
+        const auto startIdx = static_cast<int64_t>(px * samplesPerPixel);
+        const auto endIdx = std::min(static_cast<int64_t>((px + 1) * samplesPerPixel), totalSamples);
+
+        for (int channel = 0; channel < numChannels; ++channel)
+        {
+            const auto* data = sourceBuffer->getReadPointer(channel);
+            float minVal = 0.0f;
+            float maxVal = 0.0f;
+
+            for (int64_t sample = startIdx; sample < endIdx; ++sample)
+            {
+                minVal = std::min(minVal, data[sample]);
+                maxVal = std::max(maxVal, data[sample]);
+            }
+
+            peak.minVals[static_cast<size_t>(channel)] = minVal;
+            peak.maxVals[static_cast<size_t>(channel)] = maxVal;
+        }
+
+        peaks[static_cast<size_t>(px)] = peak;
     }
 }
 
 void WaveformView::paint(juce::Graphics& g)
 {
     auto bounds = getLocalBounds().toFloat();
+    auto waveBounds = getWaveBounds();
 
-    // Background with rounded corners
-    g.setColour(juce::Colour(Theme::bgControl));
+    g.setColour(juce::Colour(Theme::bgDarkest));
     g.fillRoundedRectangle(bounds, Theme::cornerRadius);
 
     if (peaks.empty() || totalSamples == 0)
     {
-        // Empty state
         g.setColour(juce::Colour(Theme::textDim));
         g.setFont(14.0f);
-        g.drawText("Drop a sample here or pick one from the browser",
-                    bounds, juce::Justification::centred);
+        g.drawFittedText("Drop a WAV file here, import one, or pick a factory sample",
+                         bounds.reduced(20.0f).toNearestInt(),
+                         juce::Justification::centred, 2);
 
         g.setColour(juce::Colour(Theme::border));
         g.drawRoundedRectangle(bounds.reduced(0.5f), Theme::cornerRadius, Theme::borderWidth);
         return;
     }
 
-    float midY = bounds.getCentreY();
-    float halfHeight = bounds.getHeight() * 0.45f;
+    const auto midY = waveBounds.getCentreY();
+    const auto halfHeight = waveBounds.getHeight() * 0.42f;
+    const auto loopStartNorm = totalSamples > 0 ? static_cast<float>(loopStartSample) / static_cast<float>(totalSamples) : 0.0f;
+    const auto loopEndNorm = totalSamples > 0 ? static_cast<float>(loopEndSample) / static_cast<float>(totalSamples) : 1.0f;
 
-    // Loop region highlight
+    g.setColour(juce::Colour(Theme::borderSubtle));
+    g.drawLine(waveBounds.getX(), midY, waveBounds.getRight(), midY, 1.0f);
+
     if (loopEndSample > loopStartSample)
     {
-        float loopStartX = normalizedToX(static_cast<float>(loopStartSample) / static_cast<float>(totalSamples));
-        float loopEndX = normalizedToX(static_cast<float>(loopEndSample) / static_cast<float>(totalSamples));
+        const auto loopStartX = normalizedToX(loopStartNorm);
+        const auto loopEndX = normalizedToX(loopEndNorm);
+        auto loopArea = juce::Rectangle<float>(loopStartX, waveBounds.getY(),
+                                               juce::jmax(2.0f, loopEndX - loopStartX),
+                                               waveBounds.getHeight());
 
-        g.setColour(juce::Colour(Theme::accentCyan).withAlpha(0.12f));
-        g.fillRect(loopStartX, bounds.getY(), loopEndX - loopStartX, bounds.getHeight());
+        g.setColour(juce::Colour(Theme::accentCyan).withAlpha(0.08f));
+        g.fillRect(loopArea);
 
-        // Loop markers
-        g.setColour(juce::Colour(Theme::accentCyan));
-        g.fillRect(loopStartX, bounds.getY(), 2.0f, bounds.getHeight());
-        g.fillRect(loopEndX - 2.0f, bounds.getY(), 2.0f, bounds.getHeight());
+        juce::ColourGradient startShadow(juce::Colour(Theme::accentCyan).withAlpha(0.16f),
+                                         loopArea.getX(), midY,
+                                         juce::Colour(Theme::accentCyan).withAlpha(0.0f),
+                                         loopArea.getX() + 12.0f, midY, false);
+        g.setGradientFill(startShadow);
+        g.fillRect(loopArea.removeFromLeft(14.0f));
+
+        auto endShadowArea = juce::Rectangle<float>(loopEndX - 14.0f, waveBounds.getY(), 14.0f, waveBounds.getHeight());
+        juce::ColourGradient endShadow(juce::Colour(Theme::accentCyan).withAlpha(0.0f),
+                                       endShadowArea.getX(), midY,
+                                       juce::Colour(Theme::accentCyan).withAlpha(0.16f),
+                                       endShadowArea.getRight(), midY, false);
+        g.setGradientFill(endShadow);
+        g.fillRect(endShadowArea);
+
+        const auto startHandle = getLoopStartHandleBounds();
+        const auto endHandle = getLoopEndHandleBounds();
+        auto drawHandle = [&](juce::Rectangle<float> handle, bool isHovered)
+        {
+            g.setColour(juce::Colour(Theme::accentCyan).withAlpha(isHovered ? 0.95f : 0.75f));
+            g.fillRoundedRectangle(handle, 4.0f);
+            g.drawLine(handle.getCentreX(), handle.getBottom(), handle.getCentreX(),
+                       waveBounds.getBottom(), 2.0f);
+        };
+
+        drawHandle(startHandle, hoverLoopStart);
+        drawHandle(endHandle, hoverLoopEnd);
     }
 
-    // Waveform
-    g.setColour(juce::Colour(Theme::accentGreen));
-    int numPeaks = static_cast<int>(peaks.size());
-    for (int i = 0; i < numPeaks; ++i)
+    auto drawChannel = [&](int channel, float alphaScale)
     {
-        float x = static_cast<float>(i);
-        float top = midY - peaks[static_cast<size_t>(i)].maxVal * halfHeight;
-        float bottom = midY - peaks[static_cast<size_t>(i)].minVal * halfHeight;
-        g.drawVerticalLine(static_cast<int>(x), top, bottom);
-    }
+        juce::Path fillPath;
+        juce::Path topPath;
+        juce::Path bottomPath;
+        std::vector<juce::Point<float>> topPoints;
+        std::vector<juce::Point<float>> bottomPoints;
+        const auto peakCount = static_cast<int>(peaks.size());
+        const auto xStep = peakCount > 1 ? waveBounds.getWidth() / static_cast<float>(peakCount - 1) : waveBounds.getWidth();
 
-    // Grain position markers
+        for (int index = 0; index < peakCount; ++index)
+        {
+            const auto& peak = peaks[static_cast<size_t>(index)];
+            if (peak.numChannels <= channel)
+                continue;
+
+            const auto x = waveBounds.getX() + static_cast<float>(index) * xStep;
+            const auto topY = midY - peak.maxVals[static_cast<size_t>(channel)] * halfHeight;
+            const auto bottomY = midY - peak.minVals[static_cast<size_t>(channel)] * halfHeight;
+            topPoints.emplace_back(x, topY);
+            bottomPoints.emplace_back(x, bottomY);
+        }
+
+        if (topPoints.empty() || bottomPoints.empty())
+            return;
+
+        fillPath.startNewSubPath(topPoints.front().x, midY);
+        topPath.startNewSubPath(topPoints.front());
+        for (const auto& point : topPoints)
+        {
+            fillPath.lineTo(point);
+            topPath.lineTo(point);
+        }
+
+        bottomPath.startNewSubPath(bottomPoints.back());
+        for (auto index = static_cast<int>(bottomPoints.size()) - 1; index >= 0; --index)
+        {
+            fillPath.lineTo(bottomPoints[static_cast<size_t>(index)]);
+            bottomPath.lineTo(bottomPoints[static_cast<size_t>(index)]);
+        }
+        fillPath.closeSubPath();
+
+        const auto accent = juce::Colour(Theme::accentGreen);
+        juce::ColourGradient gradient(accent.withAlpha(0.78f * alphaScale), 0.0f, waveBounds.getY(),
+                                      accent.withAlpha(0.30f * alphaScale), 0.0f, midY, false);
+        gradient.addColour(1.0, accent.withAlpha(0.78f * alphaScale));
+        g.setGradientFill(gradient);
+        g.fillPath(fillPath);
+
+        g.setColour(accent.withAlpha(0.92f * alphaScale));
+        const auto outlineStroke = juce::PathStrokeType(1.15f, juce::PathStrokeType::curved,
+                                                        juce::PathStrokeType::rounded);
+        g.strokePath(topPath, outlineStroke);
+        g.strokePath(bottomPath, outlineStroke);
+    };
+
+    drawChannel(0, 1.0f);
+    drawChannel(1, 0.55f);
+
     if (!grainPositions.empty())
     {
-        g.setColour(juce::Colour(Theme::accentGreen).withAlpha(0.55f));
-        for (float pos : grainPositions)
+        for (auto position : grainPositions)
         {
-            float gx = normalizedToX(pos);
-            g.fillRect(gx - 1.0f, bounds.getY() + 2.0f, 3.0f, bounds.getHeight() - 4.0f);
+            const auto grainX = normalizedToX(position);
+            juce::ColourGradient density(juce::Colour(Theme::accentGreen).withAlpha(0.0f),
+                                         grainX - 18.0f, midY,
+                                         juce::Colour(Theme::accentGreen).withAlpha(0.10f),
+                                         grainX, midY, false);
+            density.addColour(1.0, juce::Colour(Theme::accentGreen).withAlpha(0.0f));
+            g.setGradientFill(density);
+            g.fillRect(juce::Rectangle<float>(grainX - 18.0f, waveBounds.getY(), 36.0f, waveBounds.getHeight()));
+
+            g.setColour(juce::Colour(Theme::accentGreen).withAlpha(0.18f));
+            g.drawLine(grainX, waveBounds.getY(), grainX, waveBounds.getBottom(), 2.0f);
+            g.setColour(juce::Colour(Theme::accentGreen).withAlpha(0.9f));
+            g.drawLine(grainX, midY - 28.0f, grainX, midY + 28.0f, 1.5f);
         }
     }
 
-    // Playhead
     if (totalSamples > 0)
     {
-        float norm = static_cast<float>(playheadSample) / static_cast<float>(totalSamples);
-        float playX = normalizedToX(norm);
+        const auto playNorm = juce::jlimit(0.0f, 1.0f,
+                                           static_cast<float>(playheadSample) / static_cast<float>(juce::jmax<int64_t>(1, totalSamples)));
+        const auto playX = normalizedToX(playNorm);
+        g.setColour(juce::Colour(Theme::textBright).withAlpha(0.18f));
+        g.drawLine(playX, waveBounds.getY(), playX, waveBounds.getBottom(), 3.5f);
         g.setColour(juce::Colour(Theme::textBright));
-        g.fillRect(playX, bounds.getY(), 2.0f, bounds.getHeight());
+        g.drawLine(playX, waveBounds.getY(), playX, waveBounds.getBottom(), 1.5f);
+
+        juce::Path marker;
+        marker.startNewSubPath(playX - 5.0f, waveBounds.getY() + 2.0f);
+        marker.lineTo(playX + 5.0f, waveBounds.getY() + 2.0f);
+        marker.lineTo(playX, waveBounds.getY() + 10.0f);
+        marker.closeSubPath();
+        g.fillPath(marker);
     }
 
-    // Border
+    if (hoverNorm >= 0.0f)
+    {
+        const auto hoverX = normalizedToX(hoverNorm);
+        g.setColour(juce::Colour(Theme::textBright).withAlpha(0.22f));
+        g.drawLine(hoverX, waveBounds.getY(), hoverX, waveBounds.getBottom(), 1.0f);
+
+        auto tooltipText = formatHoverText(hoverNorm);
+        auto tooltipArea = juce::Rectangle<float>(lastMousePosition.x + 12.0f, lastMousePosition.y - 10.0f,
+                                                  dragMode == DragMode::none ? 82.0f : 128.0f, 22.0f);
+        tooltipArea = tooltipArea.withPosition(
+            juce::jlimit(bounds.getX() + 6.0f, bounds.getRight() - tooltipArea.getWidth() - 6.0f, tooltipArea.getX()),
+            juce::jlimit(bounds.getY() + 6.0f, bounds.getBottom() - tooltipArea.getHeight() - 6.0f, tooltipArea.getY()));
+
+        g.setColour(juce::Colour(Theme::bgPanelHover));
+        g.fillRoundedRectangle(tooltipArea, 6.0f);
+        g.setColour(juce::Colour(Theme::borderActive));
+        g.drawRoundedRectangle(tooltipArea, 6.0f, 1.0f);
+        g.setColour(juce::Colour(Theme::textBright));
+        g.setFont(juce::Font(Theme::fontMetadata));
+        g.drawFittedText(tooltipText, tooltipArea.reduced(8.0f, 4.0f).toNearestInt(),
+                         juce::Justification::centredLeft, 1);
+    }
+
     g.setColour(juce::Colour(Theme::border));
     g.drawRoundedRectangle(bounds.reduced(0.5f), Theme::cornerRadius, Theme::borderWidth);
 }
@@ -158,47 +293,99 @@ void WaveformView::resized()
 
 void WaveformView::mouseDown(const juce::MouseEvent& e)
 {
-    if (totalSamples == 0) return;
+    if (totalSamples == 0)
+        return;
 
-    isDragging = true;
-    dragStartNorm = xToNormalized(static_cast<float>(e.x));
-    dragEndNorm = dragStartNorm;
+    lastMousePosition = e.position;
+    hoverNorm = xToNormalized(e.position.x);
+
+    if (getLoopStartHandleBounds().contains(e.position))
+    {
+        dragMode = DragMode::draggingLoopStart;
+    }
+    else if (getLoopEndHandleBounds().contains(e.position))
+    {
+        dragMode = DragMode::draggingLoopEnd;
+    }
+    else
+    {
+        dragMode = DragMode::selectingRegion;
+        dragStartNorm = hoverNorm;
+        dragEndNorm = hoverNorm;
+    }
 }
 
 void WaveformView::mouseDrag(const juce::MouseEvent& e)
 {
-    if (!isDragging || totalSamples == 0) return;
+    if (totalSamples == 0 || dragMode == DragMode::none)
+        return;
 
-    dragEndNorm = xToNormalized(static_cast<float>(e.x));
-    dragEndNorm = juce::jlimit(0.0f, 1.0f, dragEndNorm);
+    constexpr float minSelection = 0.005f;
 
-    // Update visual loop region during drag
-    float start = std::min(dragStartNorm, dragEndNorm);
-    float end = std::max(dragStartNorm, dragEndNorm);
+    lastMousePosition = e.position;
+    hoverNorm = xToNormalized(e.position.x);
 
-    loopStartSample = static_cast<int64_t>(start * static_cast<float>(totalSamples));
-    loopEndSample = static_cast<int64_t>(end * static_cast<float>(totalSamples));
+    switch (dragMode)
+    {
+        case DragMode::draggingLoopStart:
+        {
+            const auto endNorm = totalSamples > 0 ? static_cast<float>(loopEndSample) / static_cast<float>(totalSamples) : 1.0f;
+            dragStartNorm = juce::jlimit(0.0f, endNorm - minSelection, hoverNorm);
+            dragEndNorm = endNorm;
+            loopStartSample = static_cast<int64_t>(dragStartNorm * static_cast<float>(totalSamples));
+            break;
+        }
 
+        case DragMode::draggingLoopEnd:
+        {
+            const auto startNorm = totalSamples > 0 ? static_cast<float>(loopStartSample) / static_cast<float>(totalSamples) : 0.0f;
+            dragStartNorm = startNorm;
+            dragEndNorm = juce::jlimit(startNorm + minSelection, 1.0f, hoverNorm);
+            loopEndSample = static_cast<int64_t>(dragEndNorm * static_cast<float>(totalSamples));
+            break;
+        }
+
+        case DragMode::selectingRegion:
+        {
+            dragEndNorm = hoverNorm;
+            const auto start = std::min(dragStartNorm, dragEndNorm);
+            const auto end = std::max(dragStartNorm, dragEndNorm);
+            loopStartSample = static_cast<int64_t>(start * static_cast<float>(totalSamples));
+            loopEndSample = static_cast<int64_t>(end * static_cast<float>(totalSamples));
+            break;
+        }
+
+        case DragMode::none:
+            break;
+    }
+
+    setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
     repaint();
 }
 
-void WaveformView::mouseUp(const juce::MouseEvent& /*e*/)
+void WaveformView::mouseUp(const juce::MouseEvent& e)
 {
-    if (!isDragging) return;
-    isDragging = false;
+    juce::ignoreUnused(e);
 
-    float start = std::min(dragStartNorm, dragEndNorm);
-    float end = std::max(dragStartNorm, dragEndNorm);
+    if (dragMode == DragMode::none)
+        return;
 
-    // Minimum selection size
-    if (end - start < 0.005f)
+    auto start = totalSamples > 0 ? static_cast<float>(loopStartSample) / static_cast<float>(totalSamples) : 0.0f;
+    auto end = totalSamples > 0 ? static_cast<float>(loopEndSample) / static_cast<float>(totalSamples) : 1.0f;
+
+    if (dragMode == DragMode::selectingRegion && end - start < 0.005f)
     {
-        // Too small — reset to full
         start = 0.0f;
         end = 1.0f;
         loopStartSample = 0;
         loopEndSample = totalSamples;
     }
+
+    dragMode = DragMode::none;
+    hoverLoopStart = getLoopStartHandleBounds().contains(lastMousePosition);
+    hoverLoopEnd = getLoopEndHandleBounds().contains(lastMousePosition);
+    setMouseCursor((hoverLoopStart || hoverLoopEnd) ? juce::MouseCursor::LeftRightResizeCursor
+                                                    : juce::MouseCursor::NormalCursor);
 
     if (loopCallback)
         loopCallback(start, end);
@@ -206,19 +393,76 @@ void WaveformView::mouseUp(const juce::MouseEvent& /*e*/)
     repaint();
 }
 
+void WaveformView::mouseMove(const juce::MouseEvent& e)
+{
+    if (totalSamples == 0)
+        return;
+
+    lastMousePosition = e.position;
+    hoverNorm = xToNormalized(e.position.x);
+    hoverLoopStart = getLoopStartHandleBounds().contains(e.position);
+    hoverLoopEnd = getLoopEndHandleBounds().contains(e.position);
+
+    setMouseCursor((hoverLoopStart || hoverLoopEnd) ? juce::MouseCursor::LeftRightResizeCursor
+                                                    : juce::MouseCursor::NormalCursor);
+    repaint();
+}
+
+void WaveformView::mouseExit(const juce::MouseEvent& e)
+{
+    juce::ignoreUnused(e);
+    hoverNorm = -1.0f;
+    hoverLoopStart = false;
+    hoverLoopEnd = false;
+    setMouseCursor(juce::MouseCursor::NormalCursor);
+    repaint();
+}
+
 void WaveformView::timerCallback()
 {
-    repaint(); // Refresh playhead
+    repaint();
 }
 
 float WaveformView::xToNormalized(float x) const
 {
-    return x / static_cast<float>(getWidth());
+    const auto waveBounds = getWaveBounds();
+    return juce::jlimit(0.0f, 1.0f, (x - waveBounds.getX()) / juce::jmax(1.0f, waveBounds.getWidth()));
 }
 
 float WaveformView::normalizedToX(float norm) const
 {
-    return norm * static_cast<float>(getWidth());
+    const auto waveBounds = getWaveBounds();
+    return waveBounds.getX() + juce::jlimit(0.0f, 1.0f, norm) * waveBounds.getWidth();
+}
+
+juce::Rectangle<float> WaveformView::getWaveBounds() const
+{
+    return getLocalBounds().toFloat().reduced(8.0f, 10.0f);
+}
+
+juce::Rectangle<float> WaveformView::getLoopStartHandleBounds() const
+{
+    const auto waveBounds = getWaveBounds();
+    const auto loopStartNorm = totalSamples > 0 ? static_cast<float>(loopStartSample) / static_cast<float>(totalSamples) : 0.0f;
+    return { normalizedToX(loopStartNorm) - 6.0f, waveBounds.getY() + 2.0f, 12.0f, 12.0f };
+}
+
+juce::Rectangle<float> WaveformView::getLoopEndHandleBounds() const
+{
+    const auto waveBounds = getWaveBounds();
+    const auto loopEndNorm = totalSamples > 0 ? static_cast<float>(loopEndSample) / static_cast<float>(totalSamples) : 1.0f;
+    return { normalizedToX(loopEndNorm) - 6.0f, waveBounds.getY() + 2.0f, 12.0f, 12.0f };
+}
+
+juce::String WaveformView::formatHoverText(float norm) const
+{
+    const auto sampleIndex = static_cast<int64_t>(norm * static_cast<float>(juce::jmax<int64_t>(1, totalSamples)));
+    const auto seconds = sourceSampleRate > 0.0 ? static_cast<double>(sampleIndex) / sourceSampleRate : 0.0;
+
+    if (dragMode == DragMode::none)
+        return juce::String(seconds, 2) + " s";
+
+    return juce::String(seconds, 2) + " s | " + juce::String(sampleIndex) + " smp";
 }
 
 } // namespace grainhex

--- a/Source/UI/WaveformView.h
+++ b/Source/UI/WaveformView.h
@@ -4,6 +4,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include "Audio/AudioTypes.h"
 #include "UI/GrainHexLookAndFeel.h"
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -44,6 +45,8 @@ public:
     void mouseDown(const juce::MouseEvent& e) override;
     void mouseDrag(const juce::MouseEvent& e) override;
     void mouseUp(const juce::MouseEvent& e) override;
+    void mouseMove(const juce::MouseEvent& e) override;
+    void mouseExit(const juce::MouseEvent& e) override;
 
     // Timer for playhead updates
     void timerCallback() override;
@@ -52,11 +55,24 @@ private:
     void generatePeakData();
     float xToNormalized(float x) const;
     float normalizedToX(float norm) const;
+    juce::Rectangle<float> getWaveBounds() const;
+    juce::Rectangle<float> getLoopStartHandleBounds() const;
+    juce::Rectangle<float> getLoopEndHandleBounds() const;
+    juce::String formatHoverText(float norm) const;
 
     struct PeakData
     {
-        float minVal = 0.0f;
-        float maxVal = 0.0f;
+        std::array<float, 2> minVals { 0.0f, 0.0f };
+        std::array<float, 2> maxVals { 0.0f, 0.0f };
+        int numChannels = 0;
+    };
+
+    enum class DragMode
+    {
+        none,
+        selectingRegion,
+        draggingLoopStart,
+        draggingLoopEnd
     };
 
     std::shared_ptr<juce::AudioBuffer<float>> sourceBuffer;
@@ -73,12 +89,17 @@ private:
     int64_t loopEndSample = 0;
 
     // Drag state
-    bool isDragging = false;
+    DragMode dragMode = DragMode::none;
     float dragStartNorm = 0.0f;
     float dragEndNorm = 0.0f;
 
     // Active grain positions (normalized)
     std::vector<float> grainPositions;
+
+    float hoverNorm = -1.0f;
+    juce::Point<float> lastMousePosition;
+    bool hoverLoopStart = false;
+    bool hoverLoopEnd = false;
 
     LoopRegionCallback loopCallback;
 


### PR DESCRIPTION
## Summary
- implement the UI redesign plan across the editor shell, waveform view, browser, granular, sub, effects, modulation, and resample panels
- add the new modulation sidebar with collapsible LFO and envelope sections, a draggable ADSR editor, and tempo-synced LFO support
- make user WAV import explicit and reliable via the import flow and drag-and-drop path, including `.wave` support

## Testing
- xcodebuild -project build-local-juce/GrainHex.xcodeproj -scheme GrainHex -configuration Debug -derivedDataPath /tmp/GrainHexDerivedData build